### PR TITLE
Bump base to core24, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 Snap recipe for the [Intel NPU Driver](https://github.com/intel/linux-npu-driver/). This snap is designed to be a producer snap providing NPU (neural processing unit) firmware, char device node access, and user-space libraries (including the user mode driver and NPU compiler) for consumption by application snaps. It exposes slots for consumer snaps to connect to (see below) but also provides firmware binary blobs for the NPU device and packages an app for validating the user space driver (`vpu-umd-test`).
 
+## Host OS Support
+
+### Meteor Lake
+
+The [`vpu-umd-test` user mode driver validation tool](#running-the-vpu-umd-test-application) is used to validate the snap with the following host OS + kernel on a [Intel Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html).
+
+| Host OS | Kernel Version | NPU Kernel Driver Support | Test Results | Comments |
+| ----- | :--: | :----------------: | :------------: | :------------------------------: |
+| 22.04 | 5.15 | :x:                | N/A            | Standard 22.04 kernel            |
+| 22.04 | 6.8  | :white_check_mark: | 184/199 passed | Hardware enablement (HWE) kernel |
+| 24.04 | 6.8  | :white_check_mark: | 184/199 passed | Standard 24.04 kernel            |
+| 24.10 | 6.11 | :white_check_mark: | 190/199 passed | Proposed 24.10 kernel            |
+
+Skipped tests on kernel 6.8 and lower only:
+
+- Metric streamer feature missing from `intel_vpu` kernel module (6 tests)
+
+Skipped tests common across all host OS and kernel versions:
+
+- GPU driver not present (2 tests)
+- DMA capabilities require tests to be run as root (3 tests)
+- Compiler in driver tests under investigation (3 tests)
+- Command queue priority under investigation (1 test)
+
 ## Instructions for building and running the snap
 
 ### Building and installing the snap locally

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Snap recipe for the [Intel NPU Driver](https://github.com/intel/linux-npu-driver
 
 ### Building and installing the snap locally
 
-**Important note**: run `snapcraft` in the current directory
-in order for the install hook to get integrated with the
-snap correctly.
+**Important note**: run `snapcraft` in the current directory in order for the install hook to get integrated with the snap correctly.
 
 Build the snap:
 
@@ -31,8 +29,7 @@ are accessible to the kernel driver running on the host.
 
 ### Loading new NPU firmware
 
-Connecting the `intel-npu-fw` plug will trigger a hook
-that customizes the kernel's firmware search path:
+Connecting the `intel-npu-fw` plug will trigger a hook that customizes the kernel's firmware search path:
 
 ```
 sudo snap connect intel-npu-driver:intel-npu-fw
@@ -66,31 +63,32 @@ sudo dmesg | grep intel_vpu
 
 ### Running the vpu-umd-test application
 
-First connect to the `custom-device` interface, which allows access to the
-NPU device node on the host:
+First connect to the `custom-device` interface, which allows access to the NPU device node on the host:
 
 ```
 sudo snap connect intel-npu-driver:intel-npu-plug intel-npu-driver:intel-npu
 ```
 
-If you have not done so already, ensure the following
-are performed in order to set up non-root access to the
-NPU device:
+If you have not done so already, ensure the following are performed in order to set up non-root access to the NPU device:
 
 ```
 sudo usermod -a -G render $USER # log out and log back in
 ```
 
-If this is your first run, or if you re-loaded the `intel_vpu` driver,
-then you'll also need to perform the following:
+If this is your first run, or if you re-loaded the `intel_vpu` driver, then you'll also need to perform the following:
 
 ```
 sudo chown root:render /dev/accel/accel0
 sudo chmod g+rw /dev/accel/accel0
 ```
 
-Create input for tests. Note, the input must be stored in a special directory
-that is accessible both inside and outside the snap.
+Create input for tests. Here we store input in a special directory that is accessible both inside and outside the snap. This directory is created the first time you run the application. This is not a strict requirement for consuming snaps, for example a consuming snap may allow access to a user's home directory through the [home interface](https://snapcraft.io/docs/home-interface).
+
+```
+intel-npu-driver.vpu-umd-test --help
+```
+
+Now move into the special directory and create the input:
 
 ```
 cd $HOME/snap/intel-npu-driver/current

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: intel-npu-driver
-base: core22
+base: core24
 version: '1.6.0'
 summary: User Mode Driver with Compiler Software for the Intel® NPU
 description: |
@@ -25,19 +25,13 @@ slots:
     udev-tagging:
       - kernel: accel[0-9]
         subsystem: accel
-        attributes:
-          vendor: "0x8086" # Intel
       - kernel: accel[1-5][0-9]
         subsystem: accel
-        attributes:
-          vendor: "0x8086" # Intel
       - kernel: accel6[0-3]
         subsystem: accel
-        attributes:
-          vendor: "0x8086" # Intel
   npu-libs:
     interface: content
-    content: npu-libs-2204
+    content: npu-libs-2404
     read:
       - $SNAP/usr/lib/x86_64-linux-gnu
 
@@ -94,3 +88,4 @@ lint:
       - usr/lib/x86_64-linux-gnu/libze_intel_vpu*
       - usr/lib/x86_64-linux-gnu/libnpu_driver_compiler*
       - usr/lib/x86_64-linux-gnu/libtbb*
+      - usr/lib/x86_64-linux-gnu/libhwloc*


### PR DESCRIPTION
Internal Jira task: [PEK-1238](https://warthogs.atlassian.net/browse/PEK-1238)

In addition to bumping to `core24`, I also made some minor tweaks to the docs and also removed the Intel vendor ID from the udev attributes field.  When I was testing this before there must've been some old rules being applied without the vendor device attribute, because the NPU device cgroup no longer gets applied to the application when I test on a freshly provisioned machine. It turns out that the `custom-device` interface allows you to add `ATTR` fields for the device but not `ATTRS` fields for the parent device.  

Tested on Locker machine provisioned with Noble. I'm hitting issues imaging with Oracular but will not merge until that is also tested.

[PEK-1238]: https://warthogs.atlassian.net/browse/PEK-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ