### PR TITLE
Add automated snap build GitHub action

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,11 @@
+name: Canonical License Agreement Check
+on:
+  pull_request:
+
+jobs:
+  cla-check:
+    name: CLA check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@main

--- a/.github/workflows/create-snap-action.yaml
+++ b/.github/workflows/create-snap-action.yaml
@@ -1,0 +1,47 @@
+name: Build and test snap
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  SNAP_ARTIFACT_NAME: intel-npu-driver-snap
+  SNAP_FILE: intel-npu-driver.snap
+
+jobs:
+  snap-build:
+    name: Build snap
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          snapcraft-args: "-o ${{ env.SNAP_FILE }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  snap-test:
+    name: Install and verify snap
+    runs-on: ubuntu-24.04
+    needs:
+      - snap-build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
+      - name: Install snap
+        run: |
+          sudo snap install --dangerous ${{ env.SNAP_FILE }}
+          snap list
+      - name: Connect snap interfaces
+        run: |
+          sudo snap connect intel-npu-driver:intel-npu-fw
+          sudo snap connect intel-npu-driver:intel-npu-plug intel-npu-driver:intel-npu
+          snap connections


### PR DESCRIPTION
This adds GitHub actions for (1) building the snap, (2) verifying that the snap can be installed, (3) connecting the snap's plugs, and (4) running the standard CLA check.

A few notes about the runner environments:

* The snap build runs on a self-hosted runner with 64GiB RAM as the build is very memory intensive and OOM errors may occur at <= 32 GiB. 

* The install test is performed on Noble (on a GitHub hosted runner) but we could expand in the future to run on different base OS's if required.