### PR TITLE
Add upstream MIT license, update grade to devel

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (C) 2022-2024 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
   the oneAPI Level-Zero and UMD with compiler libraries. It also distributes
   apps for installing firmware to a NPU device and validating the UMD.
   For more info, see https://github.com/intel/linux-npu-driver
-grade: stable
+grade: devel
 confinement: strict
 
 slots:


### PR DESCRIPTION
* Add MIT license from [upstream Intel repo](https://github.com/intel/linux-npu-driver/blob/main/LICENSE.md)
* Change snap `grade` to `devel` based on planned support model, i.e. the distribution of the snap will initially be limited to `edge` and `beta` channels only to reflect a limited support commitment