### PR TITLE
Add more detailed instructions for consumer apps

### DIFF
--- a/.github/workflows/create-snap-action.yaml
+++ b/.github/workflows/create-snap-action.yaml
@@ -2,9 +2,15 @@ name: Build and test snap
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'snap/**'
+      - 'bin/**'
     branches:
       - main
   pull_request:
+    paths:
+      - 'snap/**'
+      - 'bin/**'
     branches:
       - main
 


### PR DESCRIPTION
This adds a bit more detail to the README. I also updated the CI to only kick off when something about the snap itself changes (not just the README).