### PR TITLE
Add checkbox provider

### DIFF
--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -1,0 +1,39 @@
+# Checkbox Provider for Intel NPU Driver Snap
+
+This directory contains the Checkbox NPU Provider, including the snap recipe for building the snap and integrating with the Checkbox snap. The test plan runs the NPU user mode driver validation tool.
+
+## Installation
+
+```
+sudo snap install --classic snapcraft
+sudo snap install checkbox22
+lxd init --auto
+git clone https://github.com/canonical/intel-npu-driver-snap.git
+cd intel-npu-driver-snap/checkbox
+snapcraft
+sudo snap install --dangerous --classic ./checkbox-npu_1.0.0_amd64.snap
+```
+
+## Installing test dependencies
+
+```
+checkbox-npu.install-full-deps
+```
+
+Note this will NOT install the `intel-npu-driver` snap by default. To install the latest version from the `latest/beta` channel in the Snap Store use:
+
+```
+checkbox-npu.install-full-deps --install_from_store
+```
+
+## Automated run
+
+```
+checkbox-npu.test-runner-automated
+```
+
+## Manual run
+
+```
+checkbox-npu.test-runner
+```

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -20,7 +20,7 @@ sudo snap install --dangerous --classic ./checkbox-npu_1.0.0_amd64.snap
 checkbox-npu.install-full-deps
 ```
 
-Note this will NOT install the `intel-npu-driver` snap by default. To install the latest version from the `latest/beta` channel in the Snap Store use:
+Note this will NOT install the `intel-npu-driver` snap by default. This is by design as typically tests will be run on a modified version of the snap built and installed locally. To install the latest version from the `latest/beta` channel in the Snap Store use:
 
 ```
 checkbox-npu.install-full-deps --install_from_store

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -6,7 +6,7 @@ This directory contains the Checkbox NPU Provider, including the snap recipe for
 
 ```
 sudo snap install --classic snapcraft
-sudo snap install checkbox22
+sudo snap install checkbox24
 lxd init --auto
 git clone https://github.com/canonical/intel-npu-driver-snap.git
 cd intel-npu-driver-snap/checkbox

--- a/checkbox/bin/checkbox-cli-wrapper
+++ b/checkbox/bin/checkbox-cli-wrapper
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# wrapper around the checkbox-cli
+# checkbox-cli resolves to /snap/checkbox22/current/bin/checkbox-cli
+exec checkbox-cli "$@"

--- a/checkbox/bin/checkbox-cli-wrapper
+++ b/checkbox/bin/checkbox-cli-wrapper
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # wrapper around the checkbox-cli
-# checkbox-cli resolves to /snap/checkbox22/current/bin/checkbox-cli
+# checkbox-cli resolves to /snap/checkbox24/current/bin/checkbox-cli
 exec checkbox-cli "$@"

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -9,6 +9,7 @@ fi
 if ! command -v intel-npu-driver.vpu-umd-test 2>&1 >/dev/null
 then
   echo "Error: intel-npu-driver.vpu-umd-test could not be found!"
+  echo "Either install the intel-npu-driver snap locally or from the store (using --install_from_store)"
   exit 1
 fi
 

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+optional_arg=$1
+if [ "${optional_arg}" = "--install_from_store" ]; then
+  echo "Installing intel-npu-driver from the beta channel in the Snap Store."
+  sudo snap install --beta intel-npu-driver
+fi
+
+if ! command -v intel-npu-driver.vpu-umd-test 2>&1 >/dev/null
+then
+  echo "Error: intel-npu-driver.vpu-umd-test could not be found!"
+  exit 1
+fi
+
+# $HOME/snap/intel-npu-driver/current is created the first time
+# an app from the snap is run. We simply pass the -l (list) option
+# to generate this directory for subsequent steps.
+intel-npu-driver.vpu-umd-test -l 2>&1 >/dev/null
+
+# Exit if any of the steps below fail
+set -e
+
+# Download the data for the test and create a simple config
+cd $HOME/snap/intel-npu-driver/current
+mkdir -p models/add_abc
+curl -s -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
+touch models/add_abc/add_abc.bin
+curl -s -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.6.0/validation/umd-test/configs/basic.yaml

--- a/checkbox/bin/shell-wrapper
+++ b/checkbox/bin/shell-wrapper
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$SNAP_NAME runtime shell, type 'exit' to quit the session"
+exec bash

--- a/checkbox/bin/test-runner
+++ b/checkbox/bin/test-runner
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.certification:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::intel-npu

--- a/checkbox/bin/test-runner-automated
+++ b/checkbox/bin/test-runner-automated
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.certification:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::intel-npu
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = no
+

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -18,12 +18,12 @@ esac
 # Launcher common exports for any checkbox app #
 ################################################
 
-RUNTIME=/snap/checkbox22/current
+RUNTIME=/snap/checkbox24/current
 if [ ! -d "$RUNTIME" ]; then
-    echo "You need to install the checkbox22 snap."
+    echo "You need to install the checkbox24 snap."
     echo ""
     echo "You can do this with this command:"
-    echo "snap install checkbox22"
+    echo "snap install checkbox24"
     exit 1
 fi
 

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+case "$SNAP_ARCH" in
+    "amd64") ARCH='x86_64-linux-gnu'
+    ;;
+    "i386") ARCH='i386-linux-gnu'
+    ;;
+    "arm64") ARCH='aarch64-linux-gnu'
+    ;;
+    "armhf") ARCH='arm-linux-gnueabihf'
+    ;;
+    *)
+        echo "Unsupported architecture: $SNAP_ARCH"
+    ;;
+esac
+
+################################################
+# Launcher common exports for any checkbox app #
+################################################
+
+RUNTIME=/snap/checkbox22/current
+if [ ! -d "$RUNTIME" ]; then
+    echo "You need to install the checkbox22 snap."
+    echo ""
+    echo "You can do this with this command:"
+    echo "snap install checkbox22"
+    exit 1
+fi
+
+export LC_ALL=C.UTF-8
+PERL_VERSION=$(perl -e '$^V=~/^v(\d+\.\d+)/;print $1')
+export PERL5LIB="$PERL5LIB:$SNAP/usr/lib/$ARCH/perl/$PERL_VERSION:$SNAP/usr/lib/$ARCH/perl5/$PERL_VERSION:$SNAP/usr/share/perl/$PERL_VERSION:$SNAP/usr/share/perl5"
+export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+export PATH="$SNAP/usr/sbin:$SNAP/sbin:$SNAP/usr/bin:$SNAP/bin:/snap/bin:$PATH"
+export ALSA_CONFIG_PATH=$SNAP/usr/share/alsa/alsa.conf:$SNAP/usr/share/alsa/pcm/default.conf
+export PYTHONPATH="$SNAP/lib:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+export PATH="$SNAP/providers/checkbox-provider-npu/bin/:$PATH"
+
+if [ -e $RUNTIME/wrapper_common_classic ]; then
+  . $RUNTIME/wrapper_common_classic
+else
+  echo "ERROR: no $RUNTIME/wrapper_common_classic found"
+  exit 0
+fi
+
+exec "$@"

--- a/checkbox/checkbox-provider-npu/manage.py
+++ b/checkbox/checkbox-provider-npu/manage.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from plainbox.provider_manager import setup, N_
+
+# You can inject other stuff here but please don't go overboard.
+#
+# In particular, if you need comprehensive compilation support to get
+# your bin/ populated then please try to discuss that with us in the
+# upstream project IRC channel #checkbox on irc.freenode.net.
+
+# NOTE: one thing that you could do here, that makes a lot of sense,
+# is to compute version somehow. This may vary depending on the
+# context of your provider. Future version of PlainBox will offer git,
+# bzr and mercurial integration using the versiontools library
+# (optional)
+
+setup(
+    name='com.canonical.certification:intel-npu',
+    version="1.0",
+    description=N_("The com.canonical.certification:intel-npu provider"),
+    gettext_domain="com_canonical_certification_intel_npu",
+)

--- a/checkbox/checkbox-provider-npu/units/category.pxu
+++ b/checkbox/checkbox-provider-npu/units/category.pxu
@@ -1,0 +1,4 @@
+unit: category
+id: npu
+_name: Intel NPU user mode driver validation
+

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -1,0 +1,373 @@
+# For 1.6.0 there are known issues with the following tests
+# so we explictly filter them out below.
+# 
+# BuffersExport.GpuZeFillToNpuZeCopy
+# BuffersExport.NpuZeFillToGpuZeCopy
+# CompilerInDriver.CreatingGraphWithNullptrInputGraphExpectFailure
+# CompilerInDriver.CreatingGraphWithZeroGraphSizeExpectFailure
+# CompilerInDriver.CreatingGraphCorrectBlobFileAndDescExpectSuccess
+# CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst
+# Sizes/PrimeBuffers.importDeviceMemory/2KB
+# Sizes/PrimeBuffers.importDeviceMemory/16MB
+# Sizes/PrimeBuffers.importDeviceMemory/255MB
+
+id: umd/Umd
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Umd
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Umd.* --config=basic.yaml
+
+id: umd/Command
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Command
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Command.* --config=basic.yaml
+
+id: umd/CommandTimestamp
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandTimestamp
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandTimestamp.* --config=basic.yaml
+
+id: umd/CommandCopy
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandCopy
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandCopy.* --config=basic.yaml
+
+id: umd/CommandBarrier
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandBarrier
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandBarrier.* --config=basic.yaml
+
+id: umd/CommandStress
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandStress
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandStress.* --config=basic.yaml
+
+id: umd/Context
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Context
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Context.* --config=basic.yaml
+
+id: umd/Device
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Device
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Device.* --config=basic.yaml
+
+id: umd/Driver
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Driver
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Driver.* --config=basic.yaml
+
+id: umd/Event
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Event
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Event.* --config=basic.yaml
+
+id: umd/EventSync
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: EventSync
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=EventSync.* --config=basic.yaml
+
+id: umd/EventPool
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: EventPool
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=EventPool.* --config=basic.yaml
+
+id: umd/Fence
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Fence
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Fence.* --config=basic.yaml
+
+id: umd/FenceSync
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Fence Sync
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=FenceSync.* --config=basic.yaml
+
+id: umd/GraphNativeBase
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: GraphNativeBase
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=GraphNativeBase.* --config=basic.yaml
+
+id: umd/GraphNativeBinary
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: GraphNativeBinary
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=GraphNativeBinary.* --config=basic.yaml
+
+id: umd/CommandGraph
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandGraph
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandGraph.* --config=basic.yaml
+
+id: umd/CommandGraphLongThreaded
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandGraphLongThreaded
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
+
+id: umd/MemoryAllocation
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MemoryAllocation
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryAllocation.* --config=basic.yaml
+
+id: umd/MemoryExecution
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MemoryExecution
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryExecution.* --config=basic.yaml
+
+id: umd/MemoryAllocationThreaded
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MemoryAllocationThreaded
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
+
+id: umd/PrimeBuffers
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: PrimeBuffers
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=PrimeBuffers.* --config=basic.yaml
+
+id: umd/CommandQueuePriority
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandQueuePriority
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandQueuePriority.create*:CommandQueuePriority.executeCopy* --config=basic.yaml
+
+id: umd/CommandMemoryFill
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandMemoryFill
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandMemoryFill.* --config=basic.yaml
+
+id: umd/MultiContext
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MultiContext
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MultiContext.* --config=basic.yaml
+
+id: umd/CommandCopyPerf
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: CommandCopyPerf
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=CommandCopyPerf.* --config=basic.yaml
+
+id: umd/SystemToSystem
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: SystemToSystem
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=SystemToSystem.* --config=basic.yaml
+
+id: umd/Sizes/MemoryAllocation
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Sizes/MemoryAllocation
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
+
+id: umd/Sizes/MemoryExecution
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Sizes/MemoryExecution
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
+
+id: umd/Sizes/PrimeBuffers
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Sizes/PrimeBuffers
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
+
+#
+# The tests below require the Metric Streamer feature that
+# is only available in newer kernels.
+#
+
+id: umd/Metric
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: Metric
+estimated_duration: 2s
+command:
+  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
+    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
+    exit 0
+  fi
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=Metric.* --config=basic.yaml
+
+id: umd/MetricQueryPool
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MetricQueryPool
+estimated_duration: 2s
+command:
+  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
+    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
+    exit 0
+  fi
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryPool.* --config=basic.yaml
+
+id: umd/MetricQuery
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MetricQuery
+estimated_duration: 2s
+command:
+  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
+    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
+    exit 0
+  fi
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQuery.* --config=basic.yaml
+
+id: umd/MetricQueryCopyEngine
+category_id: npu
+flags: simple
+requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+_summary: MetricQueryCopyEngine
+estimated_duration: 2s
+command:
+  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
+    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
+    exit 0
+  fi
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -11,9 +11,30 @@
 # Sizes/PrimeBuffers.importDeviceMemory/16MB
 # Sizes/PrimeBuffers.importDeviceMemory/255MB
 
+id: kmd/CharDevicePermissions
+category_id: npu
+flags: simple
+_summary: Check that user has read and write access to NPU char device node
+estimated_duration: 2s
+command:
+  if ! test -r /dev/accel/accel0 ; then
+    >&2 echo "Test failure: user must have read permissions to /dev/accel/accel0"
+    >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+    >&2 echo "Then run 'sudo chown root:render /dev/accel/accel0 && sudo chmod g+rw /dev/accel/accel0'"
+    exit 1
+  fi
+  if ! test -w /dev/accel/accel0 ; then
+    >&2 echo "Test failure: user must have write permissions to /dev/accel/accel0"
+    >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+    >&2 echo "Then run 'sudo chown root:render /dev/accel/accel0 && sudo chmod g+rw /dev/accel/accel0'"
+    exit 1
+  fi
+  echo "Test success: user has read and write access to /dev/accel/accel0"
+
 id: umd/Umd
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Umd
 estimated_duration: 2s
@@ -24,6 +45,7 @@ command:
 id: umd/Command
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Command
 estimated_duration: 2s
@@ -34,6 +56,7 @@ command:
 id: umd/CommandTimestamp
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandTimestamp
 estimated_duration: 2s
@@ -44,6 +67,7 @@ command:
 id: umd/CommandCopy
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandCopy
 estimated_duration: 2s
@@ -54,6 +78,7 @@ command:
 id: umd/CommandBarrier
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandBarrier
 estimated_duration: 2s
@@ -64,6 +89,7 @@ command:
 id: umd/CommandStress
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandStress
 estimated_duration: 2s
@@ -74,6 +100,7 @@ command:
 id: umd/Context
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Context
 estimated_duration: 2s
@@ -84,6 +111,7 @@ command:
 id: umd/Device
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Device
 estimated_duration: 2s
@@ -94,6 +122,7 @@ command:
 id: umd/Driver
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Driver
 estimated_duration: 2s
@@ -104,6 +133,7 @@ command:
 id: umd/Event
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Event
 estimated_duration: 2s
@@ -114,6 +144,7 @@ command:
 id: umd/EventSync
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: EventSync
 estimated_duration: 2s
@@ -124,6 +155,7 @@ command:
 id: umd/EventPool
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: EventPool
 estimated_duration: 2s
@@ -134,6 +166,7 @@ command:
 id: umd/Fence
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Fence
 estimated_duration: 2s
@@ -144,6 +177,7 @@ command:
 id: umd/FenceSync
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Fence Sync
 estimated_duration: 2s
@@ -154,6 +188,7 @@ command:
 id: umd/GraphNativeBase
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: GraphNativeBase
 estimated_duration: 2s
@@ -164,6 +199,7 @@ command:
 id: umd/GraphNativeBinary
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: GraphNativeBinary
 estimated_duration: 2s
@@ -174,6 +210,7 @@ command:
 id: umd/CommandGraph
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandGraph
 estimated_duration: 2s
@@ -184,6 +221,7 @@ command:
 id: umd/CommandGraphLongThreaded
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandGraphLongThreaded
 estimated_duration: 2s
@@ -194,6 +232,7 @@ command:
 id: umd/MemoryAllocation
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MemoryAllocation
 estimated_duration: 2s
@@ -204,6 +243,7 @@ command:
 id: umd/MemoryExecution
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MemoryExecution
 estimated_duration: 2s
@@ -214,6 +254,7 @@ command:
 id: umd/MemoryAllocationThreaded
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MemoryAllocationThreaded
 estimated_duration: 2s
@@ -224,6 +265,7 @@ command:
 id: umd/PrimeBuffers
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: PrimeBuffers
 estimated_duration: 2s
@@ -234,6 +276,7 @@ command:
 id: umd/CommandQueuePriority
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandQueuePriority
 estimated_duration: 2s
@@ -244,6 +287,7 @@ command:
 id: umd/CommandMemoryFill
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandMemoryFill
 estimated_duration: 2s
@@ -254,6 +298,7 @@ command:
 id: umd/MultiContext
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MultiContext
 estimated_duration: 2s
@@ -264,6 +309,7 @@ command:
 id: umd/CommandCopyPerf
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: CommandCopyPerf
 estimated_duration: 2s
@@ -271,19 +317,21 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=CommandCopyPerf.* --config=basic.yaml
 
-id: umd/SystemToSystem
+id: umd/SystemToSystem/CommandCopyFlag
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
-_summary: SystemToSystem
+_summary: SystemToSystem/CommandCopyFlag
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=SystemToSystem.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
 
 id: umd/Sizes/MemoryAllocation
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Sizes/MemoryAllocation
 estimated_duration: 2s
@@ -294,6 +342,7 @@ command:
 id: umd/Sizes/MemoryExecution
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Sizes/MemoryExecution
 estimated_duration: 2s
@@ -304,6 +353,7 @@ command:
 id: umd/Sizes/PrimeBuffers
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Sizes/PrimeBuffers
 estimated_duration: 2s
@@ -311,63 +361,58 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
 
-#
-# The tests below require the Metric Streamer feature that
-# is only available in newer kernels.
-#
+id: kmd/MetricStreamerSupport
+category_id: npu
+flags: simple
+_summary: Test if Metric Stream support available in intel_vpu kernel module
+estimated_duration: 2s
+command:
+  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then
+    >&2 echo "Test failure: metric streamer feature not available in kernel $(uname -r), requires >= 6.9"
+    exit 1
+  fi
+  echo "Test success: metric streamer feature available in intel_npu kernel module!"
 
 id: umd/Metric
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: Metric
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
-    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
-    exit 0
-  fi
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=Metric.* --config=basic.yaml
 
 id: umd/MetricQueryPool
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MetricQueryPool
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
-    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
-    exit 0
-  fi
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryPool.* --config=basic.yaml
 
 id: umd/MetricQuery
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MetricQuery
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
-    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
-    exit 0
-  fi
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=MetricQuery.* --config=basic.yaml
 
 id: umd/MetricQueryCopyEngine
 category_id: npu
 flags: simple
+depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
 requires: executable.name == 'intel-npu-driver.vpu-umd-test'
 _summary: MetricQueryCopyEngine
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then 
-    echo "Skipping as the Metric Streamer feature is only available in kernel version > 6.8"
-    exit 0
-  fi
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml

--- a/checkbox/checkbox-provider-npu/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-npu/units/test-plan.pxu
@@ -2,6 +2,7 @@ id: intel-npu
 unit: test plan
 _name: NPU user mode driver tests
 include:
+    kmd/.*
     umd/.*
 bootstrap_include:
     com.canonical.certification::executable

--- a/checkbox/checkbox-provider-npu/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-npu/units/test-plan.pxu
@@ -1,0 +1,9 @@
+id: intel-npu
+unit: test plan
+_name: NPU user mode driver tests
+include:
+    umd/.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+

--- a/checkbox/snap/hooks/install
+++ b/checkbox/snap/hooks/install
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+snapctl set slave=enabled
+
+echo "$(id -un 1000 2>/dev/null || id -un 1001 2>/dev/null || echo ubuntu) ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/checkbox
+
+mkdir -p /etc/polkit-1/localauthority/50-local.d
+cat <<EOF > /etc/polkit-1/localauthority/50-local.d/com.canonical.certification.checkbox.pkla
+[Checkbox]
+Identity=unix-group:sudo
+Action=org.freedesktop.NetworkManager.*
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes
+EOF

--- a/checkbox/snap/hooks/remove
+++ b/checkbox/snap/hooks/remove
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+rm -f /etc/sudoers.d/checkbox
+rm -f /etc/polkit-1/localauthority/50-local.d/com.canonical.certification.checkbox.pkla || /bin/true

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ version: '1.0.0'
 confinement: classic
 grade: stable
 
-base: core22
+base: core24
 
 # Here are the available applications of the NPU checkbox provider snap
 # To run : snap run checkbox-npu.<app>
@@ -51,9 +51,9 @@ parts:
     source-type: local
     build-snaps:
       - checkbox-provider-tools
-      - checkbox22
+      - checkbox24
     override-build: |
-      for path in $(find "/snap/checkbox22/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      for path in $(find "/snap/checkbox24/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       checkbox-provider-tools validate
       checkbox-provider-tools build
       checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-npu --root="$SNAPCRAFT_PART_INSTALL"

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -1,0 +1,65 @@
+name: checkbox-npu
+summary: Checkbox tests for the intel-npu-driver snap
+description: |
+  Collection of tests using Intel's user mode driver and compiler validation tool
+version: '1.0.0'
+confinement: classic
+grade: stable
+
+base: core22
+
+# Here are the available applications of the NPU checkbox provider snap
+# To run : snap run checkbox-npu.<app>
+#
+# checkbox-cli:
+#   - checkbox client, can be used to talk to the checkbox daemon
+# remote-slave:
+#   - checkbox slave daemon that will the responsible for running the test sesssion
+#     in the remote fashion (through checkbox-cli)
+# shell:
+#   - give shell access to the provider snap
+# test-runner / test-runner-automated:
+#   - execute all provider tests inside the snap environment
+#     the test execution is standalone and does not depend on the remote-slave daemon
+# install-full-deps:
+#   - install all depedencies needed for provider jobs
+apps:
+  checkbox-cli:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper
+  remote-slave:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper slave
+    daemon: simple
+    restart-condition: always
+  shell:
+    command-chain: [bin/wrapper_local]
+    command: bin/shell-wrapper
+  test-runner:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-runner
+  test-runner-automated:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-runner-automated
+  install-full-deps:
+    command: bin/install-full-deps
+
+parts:
+  checkbox-provider-npu:
+    plugin: dump
+    source: ./checkbox-provider-npu
+    source-type: local
+    build-snaps:
+      - checkbox-provider-tools
+      - checkbox22
+    override-build: |
+      for path in $(find "/snap/checkbox22/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      checkbox-provider-tools validate
+      checkbox-provider-tools build
+      checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-npu --root="$SNAPCRAFT_PART_INSTALL"
+
+  bin:
+    plugin: dump
+    source: bin
+    organize:
+      '*': bin/


### PR DESCRIPTION
This adds an Intel NPU checkbox provider for the `intel-npu-driver` snap. The test plan runs the `vpu-umd-test` command that is installed inside the driver snap.

I used the existing providers for tdx and dss as a reference.

Internal Jira task: [PEK-1240](https://warthogs.atlassian.net/browse/PEK-1240)

I plan a follow-up PR to update the CI to run the checkbox tests on a testflinger device equpped with a NPU.

[PEK-1240]: https://warthogs.atlassian.net/browse/PEK-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ