### PR TITLE
Testflinger CI Integration

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -93,7 +93,7 @@ test_data:
     # Build and install checkbox-npu snap
     ssh ubuntu@$DEVICE_IP '
       cd ~ubuntu/intel-npu-driver-snap/checkbox
-      sudo snap install checkbox24
+      sudo snap install checkbox22
       snapcraft
       sudo snap install --dangerous --classic ./checkbox-npu_*_amd64.snap
     '

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,0 +1,120 @@
+job_queue: REPLACE_QUEUE
+output_timeout: 7200
+provision_data:
+  REPLACE_PROVISION_DATA
+test_data:
+  test_cmds: |
+
+    # Exit immediately if a test fails
+    set -e
+
+    # Clone repo from appropriate branch/commit.
+    ssh ubuntu@$DEVICE_IP '
+      sudo DEBIAN_FRONTEND=noninteractive apt update
+      sudo DEBIAN_FRONTEND=noninteractive apt -y upgrade
+      sudo DEBIAN_FRONTEND=noninteractive apt -y install git curl
+      git clone -b REPLACE_BRANCH \
+        https://github.com/canonical/intel-npu-driver-snap.git \
+        ~ubuntu/intel-npu-driver-snap
+      cd ~ubuntu/intel-npu-driver-snap
+      echo "Current git branch: $(git branch --show-current)"
+      echo "Latest commit:"
+      git log --name-status HEAD^..HEAD
+    '
+
+    # Install dependencies
+    ssh ubuntu@$DEVICE_IP '
+      sudo snap install --classic snapcraft
+      sudo snap install lxd --channel=5.21/stable
+      sudo adduser ubuntu lxd
+      sudo snap refresh
+    '
+
+    # Disable swap and IPv6
+    ssh ubuntu@$DEVICE_IP '
+      sudo sysctl -w vm.swappiness=0
+      sudo echo "vm.swappiness = 0" | sudo tee -a /etc/sysctl.conf
+      sudo swapoff -a
+      echo "net.ipv6.conf.all.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.default.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.lo.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+    '
+
+    # Build and install intel-npu-driver snap
+    ssh ubuntu@$DEVICE_IP '
+      lxd init --auto
+      cd ~ubuntu/intel-npu-driver-snap
+      snapcraft
+      sudo snap install --dangerous ./intel-npu-driver_*_amd64.snap
+      sudo snap connect intel-npu-driver:intel-npu-fw
+      sudo snap connect intel-npu-driver:intel-npu-kmod
+      sudo snap connect intel-npu-driver:intel-npu-plug intel-npu-driver:intel-npu
+    '
+
+    echo "[INFO]: Sleeping for 60 seconds to ensure the firmware search path is updated."
+    sleep 60
+
+    # Check firmware is deployed to the expected path
+    ssh ubuntu@$DEVICE_IP '
+      set -e
+      fw_search_path=$(sudo cat /sys/module/firmware_class/parameters/path)
+      echo "[INFO]: fw_search_path: ${fw_search_path}"
+      echo "[INFO]: $(snap services intel-npu-driver.load-npu-firmware)"
+      echo "[INFO]: $(sudo snap logs intel-npu-driver.load-npu-firmware)"
+      if [ -z "${fw_search_path}" ]; then
+        >&2 echo "Test error: Firmware search path not updated."
+        exit 1
+      fi
+      echo "Checking for firmware in expected path..."
+      ls "${fw_search_path}"/intel/vpu/ | grep ".*.bin$"
+      echo "Test success: Found .bin file(s) in the expected path."
+    '
+
+    # Check that the firmware is the expected version
+    ssh ubuntu@$DEVICE_IP '
+      set -e
+      if [ $(uname -r | cut -f2 -d.) -lt 8 ]; then
+        echo "[INFO]: intel_vpu kernel module does not show firmware version in dmesg"
+        exit 0
+      fi
+      snap_version=$(snap list intel-npu-driver | grep -Eo "([0-9]{1,}\.)+[0-9]{1,}")
+      if [ "${snap_version}" = "1.6.0" ]; then
+        echo "[INFO]: dmesg logs for intel_vpu kernel module: $(sudo dmesg | grep intel_vpu)"
+        intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
+        echo "${intel_vpu_dmesg}" | grep -w "20240726*MTL_CLIENT_SILICON-release*0004*ci_tag_ud202428_vpu_rc_20240726_0004*e4a99ed6b3e"
+        echo "Test success: expected firmware version successfully loaded to NPU device!"
+      else
+        >&2 echo "Test error: unexpected snap version ${snap_version}"
+        exit 1
+      fi
+    '
+
+    # Build and install checkbox-npu snap
+    ssh ubuntu@$DEVICE_IP '
+      cd ~ubuntu/intel-npu-driver-snap/checkbox
+      sudo snap install checkbox24
+      snapcraft
+      sudo snap install --dangerous --classic ./checkbox-npu_*_amd64.snap
+    '
+
+    # Enable non-root access to the NPU device node
+    ssh ubuntu@$DEVICE_IP '
+      sudo usermod -a -G render $USER
+      sudo chown root:render /dev/accel/accel0
+      sudo chmod g+rw /dev/accel/accel0
+    '
+
+    # Install test dependencies
+    ssh ubuntu@$DEVICE_IP '
+      checkbox-npu.install-full-deps
+    '
+
+    # Run tests
+    ssh ubuntu@$DEVICE_IP '
+      checkbox-npu.test-runner-automated
+    '
+reserve_data:
+  ssh_keys:
+    - lp:wfrench
+  timeout: 21600

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -114,7 +114,3 @@ test_data:
     ssh ubuntu@$DEVICE_IP '
       checkbox-npu.test-runner-automated
     '
-reserve_data:
-  ssh_keys:
-    - lp:wfrench
-  timeout: 21600

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,15 +5,20 @@ on:
     paths:
       - 'snap/**'
       - 'bin/**'
+      - 'checkbox/bin/**'
+      - 'checkbox/checkbox-provider-npu/**'
+      - 'checkbox/snap/**'
       - '.github/workflows/integration-tests.yaml'
       - '.github/testflinger/job-def.yaml'
     branches:
       - main
-      - frenchwr/testflinger-ci-integration # temporary
   pull_request:
     paths:
       - 'snap/**'
       - 'bin/**'
+      - 'checkbox/bin/**'
+      - 'checkbox/checkbox-provider-npu/**'
+      - 'checkbox/snap/**'
       - '.github/workflows/integration-tests.yaml'
       - '.github/testflinger/job-def.yaml'
     branches:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,46 @@
+name: Build snap and run integration tests on testflinger device
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'snap/**'
+      - 'bin/**'
+      - '.github/workflows/integration-tests.yaml'
+      - '.github/testflinger/job-def.yaml'
+    branches:
+      - main
+      - frenchwr/testflinger-ci-integration # temporary
+  pull_request:
+    paths:
+      - 'snap/**'
+      - 'bin/**'
+      - '.github/workflows/integration-tests.yaml'
+      - '.github/testflinger/job-def.yaml'
+    branches:
+      - main
+
+env:
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  npu-driver-validation:
+    name: NPU Driver Validation
+    runs-on: [testflinger]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build job file from template with oemscript provisioning
+        env:
+          QUEUE: "dell-xps-13-9340-c32267"
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
+        run: |
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/job.yaml
+      - name: Submit testflinger job
+        uses: canonical/testflinger/.github/actions/submit@main
+        with:
+          poll: true
+          job-path: ${GITHUB_WORKSPACE}/job.yaml

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -8,7 +8,6 @@ on:
       - '.github/workflows/smoke-tests.yaml'
     branches:
       - main
-      - frenchwr/testflinger-ci-integration # temporary
   pull_request:
     paths:
       - 'snap/**'

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,16 +1,19 @@
-name: Build and test snap
+name: Build snap and run smoke tests
 on:
   workflow_dispatch:
   push:
     paths:
       - 'snap/**'
       - 'bin/**'
+      - '.github/workflows/smoke-tests.yaml'
     branches:
       - main
+      - frenchwr/testflinger-ci-integration # temporary
   pull_request:
     paths:
       - 'snap/**'
       - 'bin/**'
+      - '.github/workflows/smoke-tests.yaml'
     branches:
       - main
 
@@ -43,11 +46,22 @@ jobs:
         with:
           name: ${{ env.SNAP_ARTIFACT_NAME }}
       - name: Install snap
+        shell: bash
         run: |
           sudo snap install --dangerous ${{ env.SNAP_FILE }}
           snap list
-      - name: Connect snap interfaces
+      - name: Check autoconnecting snap interfaces
+        shell: bash
         run: |
-          sudo snap connect intel-npu-driver:intel-npu-fw
-          sudo snap connect intel-npu-driver:intel-npu-plug intel-npu-driver:intel-npu
-          snap connections
+          snap connections intel-npu-driver | grep -w custom-device
+          snap connections intel-npu-driver | grep -w kernel-firmware-control
+          snap connections intel-npu-driver | grep -w kernel-module-control
+      - name: Verify that the load-npu-firmware service is enabled
+        shell: bash
+        run: |
+          snap services intel-npu-driver.load-npu-firmware | grep -w enabled
+      - name: Verify that the user mode driver validation tool is deployed in the snap
+        shell: bash
+        run: |
+          echo "Checking for the user mode driver command in the snap..."
+          command -V intel-npu-driver.vpu-umd-test

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -6,7 +6,7 @@ This directory contains the Checkbox NPU Provider, including the snap recipe for
 
 ```
 sudo snap install --classic snapcraft
-sudo snap install checkbox24
+sudo snap install checkbox22
 lxd init --auto
 git clone https://github.com/canonical/intel-npu-driver-snap.git
 cd intel-npu-driver-snap/checkbox

--- a/checkbox/bin/checkbox-cli-wrapper
+++ b/checkbox/bin/checkbox-cli-wrapper
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 # wrapper around the checkbox-cli
-# checkbox-cli resolves to /snap/checkbox24/current/bin/checkbox-cli
-exec checkbox-cli "$@"
+exec /snap/checkbox22/current/bin/checkbox-cli "$@"

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -18,12 +18,12 @@ esac
 # Launcher common exports for any checkbox app #
 ################################################
 
-RUNTIME=/snap/checkbox24/current
+RUNTIME=/snap/checkbox22/current
 if [ ! -d "$RUNTIME" ]; then
-    echo "You need to install the checkbox24 snap."
+    echo "You need to install the checkbox22 snap."
     echo ""
     echo "You can do this with this command:"
-    echo "snap install checkbox24"
+    echo "snap install checkbox22"
     exit 1
 fi
 

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -40,7 +40,7 @@ _summary: Umd
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Umd.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Umd.* --config=basic.yaml
 
 id: umd/Command
 category_id: npu
@@ -51,7 +51,7 @@ _summary: Command
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Command.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Command.* --config=basic.yaml
 
 id: umd/CommandTimestamp
 category_id: npu
@@ -62,7 +62,7 @@ _summary: CommandTimestamp
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandTimestamp.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandTimestamp.* --config=basic.yaml
 
 id: umd/CommandCopy
 category_id: npu
@@ -73,7 +73,7 @@ _summary: CommandCopy
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandCopy.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandCopy.* --config=basic.yaml
 
 id: umd/CommandBarrier
 category_id: npu
@@ -84,7 +84,7 @@ _summary: CommandBarrier
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandBarrier.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandBarrier.* --config=basic.yaml
 
 id: umd/CommandStress
 category_id: npu
@@ -95,7 +95,7 @@ _summary: CommandStress
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandStress.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandStress.* --config=basic.yaml
 
 id: umd/Context
 category_id: npu
@@ -106,7 +106,7 @@ _summary: Context
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Context.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Context.* --config=basic.yaml
 
 id: umd/Device
 category_id: npu
@@ -117,7 +117,7 @@ _summary: Device
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Device.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Device.* --config=basic.yaml
 
 id: umd/Driver
 category_id: npu
@@ -128,7 +128,7 @@ _summary: Driver
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Driver.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Driver.* --config=basic.yaml
 
 id: umd/Event
 category_id: npu
@@ -139,7 +139,7 @@ _summary: Event
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Event.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Event.* --config=basic.yaml
 
 id: umd/EventSync
 category_id: npu
@@ -150,7 +150,7 @@ _summary: EventSync
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=EventSync.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=EventSync.* --config=basic.yaml
 
 id: umd/EventPool
 category_id: npu
@@ -161,7 +161,7 @@ _summary: EventPool
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=EventPool.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=EventPool.* --config=basic.yaml
 
 id: umd/Fence
 category_id: npu
@@ -172,7 +172,7 @@ _summary: Fence
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Fence.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Fence.* --config=basic.yaml
 
 id: umd/FenceSync
 category_id: npu
@@ -183,7 +183,7 @@ _summary: Fence Sync
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=FenceSync.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=FenceSync.* --config=basic.yaml
 
 id: umd/GraphNativeBase
 category_id: npu
@@ -194,7 +194,7 @@ _summary: GraphNativeBase
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=GraphNativeBase.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=GraphNativeBase.* --config=basic.yaml
 
 id: umd/GraphNativeBinary
 category_id: npu
@@ -205,7 +205,7 @@ _summary: GraphNativeBinary
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=GraphNativeBinary.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=GraphNativeBinary.* --config=basic.yaml
 
 id: umd/CommandGraph
 category_id: npu
@@ -216,7 +216,7 @@ _summary: CommandGraph
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandGraph.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandGraph.* --config=basic.yaml
 
 id: umd/CommandGraphLongThreaded
 category_id: npu
@@ -227,7 +227,7 @@ _summary: CommandGraphLongThreaded
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
 
 id: umd/MemoryAllocation
 category_id: npu
@@ -238,7 +238,7 @@ _summary: MemoryAllocation
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryAllocation.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryAllocation.* --config=basic.yaml
 
 id: umd/MemoryExecution
 category_id: npu
@@ -249,7 +249,7 @@ _summary: MemoryExecution
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryExecution.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryExecution.* --config=basic.yaml
 
 id: umd/MemoryAllocationThreaded
 category_id: npu
@@ -260,7 +260,7 @@ _summary: MemoryAllocationThreaded
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
 
 id: umd/PrimeBuffers
 category_id: npu
@@ -271,7 +271,7 @@ _summary: PrimeBuffers
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=PrimeBuffers.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=PrimeBuffers.* --config=basic.yaml
 
 id: umd/CommandQueuePriority
 category_id: npu
@@ -282,7 +282,7 @@ _summary: CommandQueuePriority
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandQueuePriority.create*:CommandQueuePriority.executeCopy* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandQueuePriority.create*:CommandQueuePriority.executeCopy* --config=basic.yaml
 
 id: umd/CommandMemoryFill
 category_id: npu
@@ -293,7 +293,7 @@ _summary: CommandMemoryFill
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandMemoryFill.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandMemoryFill.* --config=basic.yaml
 
 id: umd/MultiContext
 category_id: npu
@@ -304,7 +304,7 @@ _summary: MultiContext
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MultiContext.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MultiContext.* --config=basic.yaml
 
 id: umd/CommandCopyPerf
 category_id: npu
@@ -315,7 +315,7 @@ _summary: CommandCopyPerf
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=CommandCopyPerf.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandCopyPerf.* --config=basic.yaml
 
 id: umd/SystemToSystem/CommandCopyFlag
 category_id: npu
@@ -326,7 +326,7 @@ _summary: SystemToSystem/CommandCopyFlag
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
 
 id: umd/Sizes/MemoryAllocation
 category_id: npu
@@ -337,7 +337,7 @@ _summary: Sizes/MemoryAllocation
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
 
 id: umd/Sizes/MemoryExecution
 category_id: npu
@@ -348,7 +348,7 @@ _summary: Sizes/MemoryExecution
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
 
 id: umd/Sizes/PrimeBuffers
 category_id: npu
@@ -359,60 +359,68 @@ _summary: Sizes/PrimeBuffers
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
 
-id: kmd/MetricStreamerSupport
+id: metric_streamer
 category_id: npu
-flags: simple
-_summary: Test if Metric Stream support available in intel_vpu kernel module
+plugin: resource
+_description: Creates resource for metric streamer feature support
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -le 8 ]; then
-    >&2 echo "Test failure: metric streamer feature not available in kernel $(uname -r), requires >= 6.9"
-    exit 1
+  if [ $(uname -r | cut -f2 -d.) -gt 8 ]; then
+    echo "state: supported"
+  else
+    echo "state: unsupported"
   fi
-  echo "Test success: metric streamer feature available in intel_npu kernel module!"
 
 id: umd/Metric
 category_id: npu
 flags: simple
-depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+depends: kmd/CharDevicePermissions
+requires:
+  executable.name == 'intel-npu-driver.vpu-umd-test'
+  metric_streamer.state == 'supported'
 _summary: Metric
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=Metric.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=Metric.* --config=basic.yaml
 
 id: umd/MetricQueryPool
 category_id: npu
 flags: simple
-depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+depends: kmd/CharDevicePermissions
+requires:
+  executable.name == 'intel-npu-driver.vpu-umd-test'
+  metric_streamer.state == 'supported'
 _summary: MetricQueryPool
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryPool.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQueryPool.* --config=basic.yaml
 
 id: umd/MetricQuery
 category_id: npu
 flags: simple
-depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+depends: kmd/CharDevicePermissions
+requires:
+  executable.name == 'intel-npu-driver.vpu-umd-test'
+  metric_streamer.state == 'supported'
 _summary: MetricQuery
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQuery.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQuery.* --config=basic.yaml
 
 id: umd/MetricQueryCopyEngine
 category_id: npu
 flags: simple
-depends: kmd/CharDevicePermissions kmd/MetricStreamerSupport
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+depends: kmd/CharDevicePermissions
+requires:
+  executable.name == 'intel-npu-driver.vpu-umd-test'
+  metric_streamer.state == 'supported'
 _summary: MetricQueryCopyEngine
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml
+  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ version: '1.0.0'
 confinement: classic
 grade: stable
 
-base: core24
+base: core22
 
 # Here are the available applications of the NPU checkbox provider snap
 # To run : snap run checkbox-npu.<app>
@@ -51,9 +51,9 @@ parts:
     source-type: local
     build-snaps:
       - checkbox-provider-tools
-      - checkbox24
+      - checkbox22
     override-build: |
-      for path in $(find "/snap/checkbox24/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      for path in $(find "/snap/checkbox22/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       checkbox-provider-tools validate
       checkbox-provider-tools build
       checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-npu --root="$SNAPCRAFT_PART_INSTALL"


### PR DESCRIPTION
Internal JIRA card: [PEK-1240](https://warthogs.atlassian.net/browse/PEK-1240)

* Add integration testing on MTL-equipped testflinger machine running 22.04 + 6.5 OEM-based kernel
* Downgrade `checkbox-npu` to `core22` to avoid GLIBC errors on 22.04 host
* Add -S flag to `vpu-umd-test` runs to avoid skipping tests (force everything to run to let checkbox properly report failures)
* Switch kernel check to a checkbox resource for testing metric streamer support in the `intel_vpu` kernel driver. Previously this was a implemented as a normal test that would fail and result in a non-zero exit code for the entire test plan, which is not the desired behavior.

Unfortunate side note: the testflinger job takes over 3 hours to run. A large chunk (over an hour) of that is spent building the NPU driver snap. Another big chunk is spent in oemscript-based provisioning. Snaps are also intermittently taking a very long time to download from the store.

[PEK-1240]: https://warthogs.atlassian.net/browse/PEK-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ