### PR TITLE
Bump version to 1.10.1

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -71,25 +71,6 @@ test_data:
       echo "Test success: Found .bin file(s) in the expected path."
     '
 
-    # Check that the firmware is the expected version
-    ssh ubuntu@$DEVICE_IP '
-      set -e
-      if [ $(uname -r | cut -f2 -d.) -lt 8 ]; then
-        echo "[INFO]: intel_vpu kernel module does not show firmware version in dmesg"
-        exit 0
-      fi
-      snap_version=$(snap list intel-npu-driver | grep -Eo "([0-9]{1,}\.)+[0-9]{1,}")
-      if [ "${snap_version}" = "1.6.0" ]; then
-        echo "[INFO]: dmesg logs for intel_vpu kernel module: $(sudo dmesg | grep intel_vpu)"
-        intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
-        echo "${intel_vpu_dmesg}" | grep -w "20240726*MTL_CLIENT_SILICON-release*0004*ci_tag_ud202428_vpu_rc_20240726_0004*e4a99ed6b3e"
-        echo "Test success: expected firmware version successfully loaded to NPU device!"
-      else
-        >&2 echo "Test error: unexpected snap version ${snap_version}"
-        exit 1
-      fi
-    '
-
     # Build and install checkbox-npu snap
     ssh ubuntu@$DEVICE_IP '
       cd ~ubuntu/intel-npu-driver-snap/checkbox

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -63,4 +63,4 @@ jobs:
         shell: bash
         run: |
           echo "Checking for the user mode driver command in the snap..."
-          command -V intel-npu-driver.vpu-umd-test
+          command -V intel-npu-driver.npu-umd-test

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Intel NPU Driver Snap
 
-Snap recipe for the [Intel NPU Driver](https://github.com/intel/linux-npu-driver/). This snap is designed to be a producer snap providing NPU (neural processing unit) firmware, char device node access, and user-space libraries (including the user mode driver and NPU compiler) for consumption by application snaps. It exposes slots for consumer snaps to connect to (see below) but also provides firmware binary blobs for the NPU device and packages an app for validating the user space driver (`vpu-umd-test`).
+Snap recipe for the [Intel NPU Driver](https://github.com/intel/linux-npu-driver/). This snap is designed to be a producer snap providing NPU (neural processing unit) firmware, char device node access, and user-space libraries (including the user mode driver and NPU compiler) for consumption by application snaps. It exposes slots for consumer snaps to connect to (see below) but also provides firmware binary blobs for the NPU device and packages an app for validating the user space driver (`npu-umd-test`).
 
 ## Host OS Support
 
 ### Meteor Lake
 
-The [`vpu-umd-test` user mode driver validation tool](#running-the-vpu-umd-test-application) is used to validate the snap with the following host OS + kernel on a [Intel Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html).
+The [`npu-umd-test` user mode driver validation tool](#running-the-npu-umd-test-application) is used to validate the snap with the following host OS + kernel on a [Intel Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html).
 
 | Host OS | Kernel Version | NPU Kernel Driver Support | Test Results | Comments |
 | ----- | :--: | :----------------: | :------------: | :------------------------------: |
@@ -106,7 +106,7 @@ Typical output:
 
 In this example output the system initially boots with the firmware that ships with OS before reloading more recent firmware provided by the snap. Check the [upstream repo from Intel](https://github.com/intel/linux-npu-driver/releases) for the expected firmware version for your platform.
 
-### Running the vpu-umd-test application
+### Running the npu-umd-test application
 
 To allow non-root access to the NPU device, first ensure the appropriate user is in the `render` Unix group:
 
@@ -124,7 +124,7 @@ sudo chmod g+rw /dev/accel/accel0
 Create input for tests. Here we store input in a special directory that is accessible both inside and outside the snap. This directory is created the first time you run the application. This is not a strict requirement for consuming snaps, for example a consuming snap may allow access to a user's home directory through the [home interface](https://snapcraft.io/docs/home-interface).
 
 ```
-intel-npu-driver.vpu-umd-test --help
+intel-npu-driver.npu-umd-test --help
 ```
 
 Now move into the special directory and create the input:
@@ -134,11 +134,11 @@ cd $HOME/snap/intel-npu-driver/current
 mkdir -p models/add_abc
 curl -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
 touch models/add_abc/add_abc.bin
-curl -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.6.0/validation/umd-test/configs/basic.yaml
+curl -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.10.1/validation/umd-test/configs/basic.yaml
 ```
 
 Finally run the application:
 
 ```
-intel-npu-driver.vpu-umd-test --config=basic.yaml
+intel-npu-driver.npu-umd-test --config=basic.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # Intel NPU Driver Snap
 
-Snap recipe for the [Intel NPU Driver](https://github.com/intel/linux-npu-driver/). This snap is designed to be a producer snap providing NPU (neural processing unit) firmware, char device node access, and user-space libraries (including the user mode driver and NPU compiler) for consumption by application snaps. It exposes slots for consumer snaps to connect to (see below) but also provides firmware binary blobs for the NPU device and packages an app for validating the user space driver (`npu-umd-test`).
+Snap recipe for the [Intel NPU user mode driver](https://github.com/intel/linux-npu-driver/). This snap is designed to be a content producer snap providing NPU (neural processing unit) firmware, char device node access, and user-space libraries (including the user mode driver and NPU compiler) for consumption by application snaps. It exposes slots for content consumer snaps to connect with, provides firmware binary blobs for the NPU device, and distributes an app for validating the user space driver (`npu-umd-test`).
 
 ## Host OS Support
 
-### Meteor Lake
+One advantage of packaging the NPU software stack as a snap is the portability across different OS versions and even Linux distributions. The main requirements for running are (i) support for snaps and (ii) a reasonably recent kernel version containing the NPU kernel driver.
 
-The [`npu-umd-test` user mode driver validation tool](#running-the-npu-umd-test-application) is used to validate the snap with the following host OS + kernel on a [Intel Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html).
+### Validation on Ubuntu
 
-| Host OS | Kernel Version | NPU Kernel Driver Support | Test Results | Comments |
-| ----- | :--: | :----------------: | :------------: | :------------------------------: |
-| 22.04 | 5.15 | :x:                | N/A            | Standard 22.04 kernel            |
-| 22.04 | 6.8  | :white_check_mark: | 184/199 passed | Hardware enablement (HWE) kernel |
-| 24.04 | 6.8  | :white_check_mark: | 184/199 passed | Standard 24.04 kernel            |
-| 24.10 | 6.11 | :white_check_mark: | 190/199 passed | Proposed 24.10 kernel            |
+We have validated the snap using the [`npu-umd-test` user mode driver validation tool](#running-the-npu-umd-test-application) on the following versions of Ubuntu running either a meteor lake [Intel Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html) or lunar lake [Intel Core Ultra 7 268V](https://www.intel.com/content/www/us/en/products/sku/240958/intel-core-ultra-7-processor-268v-12m-cache-up-to-5-00-ghz/specifications.html) processor.
+
+| Host OS | Kernel Version | NPU Kernel Driver Support | Test Results |
+| ----- | :--: | :----------------: | :------------: |
+| 22.04 | 5.15 | :x:                | N/A            |
+| 24.04 | 6.8  | :white_check_mark: | 185/200 passed |
+| 24.10 | 6.11 | :white_check_mark: | 191/200 passed |
 
 Skipped tests on kernel 6.8 and lower only:
 
@@ -23,14 +24,23 @@ Skipped tests common across all host OS and kernel versions:
 
 - GPU driver not present (2 tests)
 - DMA capabilities require tests to be run as root (3 tests)
-- Compiler in driver tests under investigation (3 tests)
+- Command graph long and command graph long threaded under investigation (2 tests)
 - Command queue priority under investigation (1 test)
+- Device GetZesEngineGetActivity under investigation (1 test)
 
 ## Instructions for building and running the snap
 
+To install the snap, you most likely want to install it from the Snap Store. For development, you may also build (note that this is resource intensive) and install it locally.
+
+### Installing the snap from the snap store
+
+```
+sudo snap install intel-npu-driver --beta
+```
+
 ### Building and installing the snap locally
 
-**Important note**: run `snapcraft` in the current directory in order for the install hook to get integrated with the snap correctly.
+**Important note**: run `snapcraft` in the root directory of the repo in order for hooks to be integrated with the snap correctly.
 
 Build the snap:
 

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -6,9 +6,9 @@ if [ "${optional_arg}" = "--install_from_store" ]; then
   sudo snap install --beta intel-npu-driver
 fi
 
-if ! command -v intel-npu-driver.vpu-umd-test 2>&1 >/dev/null
+if ! command -v intel-npu-driver.npu-umd-test 2>&1 >/dev/null
 then
-  echo "Error: intel-npu-driver.vpu-umd-test could not be found!"
+  echo "Error: intel-npu-driver.npu-umd-test could not be found!"
   echo "Either install the intel-npu-driver snap locally or from the store (using --install_from_store)"
   exit 1
 fi
@@ -16,7 +16,7 @@ fi
 # $HOME/snap/intel-npu-driver/current is created the first time
 # an app from the snap is run. We simply pass the -l (list) option
 # to generate this directory for subsequent steps.
-intel-npu-driver.vpu-umd-test -l 2>&1 >/dev/null
+intel-npu-driver.npu-umd-test -l 2>&1 >/dev/null
 
 # Exit if any of the steps below fail
 set -e

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -26,4 +26,4 @@ cd $HOME/snap/intel-npu-driver/current
 mkdir -p models/add_abc
 curl -s -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
 touch models/add_abc/add_abc.bin
-curl -s -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.6.0/validation/umd-test/configs/basic.yaml
+curl -s -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.10.1/validation/umd-test/configs/basic.yaml

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -31,6 +31,76 @@ command:
   fi
   echo "Test success: user has read and write access to /dev/accel/accel0"
 
+id: dmesg_logs_firmware_version
+category_id: npu
+plugin: resource
+_description: Creates resource for firwmare version logging support in dmesg
+estimated_duration: 2s
+command:
+  # support added in kernel version 6.8
+  MIN_VERSION=6.8
+  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
+  if [ "${result}" = "${MIN_VERSION}" ]; then
+    # indicates that the running kernel is >= 6.8
+    echo "state: supported"
+  else
+    echo "state: unsupported"
+  fi
+
+id: npu_type
+category_id: npu
+plugin: resource
+_description: Creates resource for type of NPU
+estimated_duration: 2s
+command:
+  if lspci -nn | grep "Meteor Lake NPU"; then
+    echo "name: meteor_lake"
+  elif lspci -nn | grep "Lunar Lake NPU"; then
+    echo "name: lunar_lake"
+  elif lspci -nn | grep "Arrow Lake NPU"; then
+    echo "name: arrow_lake"
+  fi
+
+id: kmd/firmware_version_meteor_and_arrow_lake
+category_id: npu
+flags: simple
+requires:
+  dmesg_logs_firmware_version.state == 'supported'
+  npu_type.name in ['meteor_lake', 'arrow_lake']
+_summary: Check NPU firmware version for Meteor Lake and Arrow Lake
+estimated_duration: 2s
+command:
+  printf "[INFO]: dmesg logs for intel_vpu kernel module:\n $(sudo dmesg | grep intel_vpu)"
+  intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
+  # Expected version strings: https://github.com/intel/linux-npu-driver/releases/tag/v1.10.1
+  EXPECTED_VERSION="20241025\*MTL_CLIENT_SILICON-release\*1830\*ci_tag_ud202444_vpu_rc_20241025_1830\*ae072b315bc"
+  if echo "${intel_vpu_dmesg}" | grep -w "${EXPECTED_VERSION}"; then
+    echo "Test success: expected firmware version successfully loaded to NPU device!"
+  else
+    >&2 echo "Test failure: NPU not running expected version ${EXPECTED_VERSION}"
+    exit 1
+  fi
+
+id: kmd/firmware_version_lunar_lake
+category_id: npu
+flags: simple
+requires:
+  dmesg_logs_firmware_version.state == 'supported'
+  npu_type.name == 'lunar_lake'
+_summary: Check NPU firmware version for Lunar Lake
+estimated_duration: 2s
+command:
+  printf "[INFO]: dmesg logs for intel_vpu kernel module:\n $(sudo dmesg | grep intel_vpu)"
+  intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
+  # Expected version strings: https://github.com/intel/linux-npu-driver/releases/tag/v1.10.1
+  EXPECTED_VERSION="Oct 25 2024\*NPU40xx\*ci_tag_ud202444_vpu_eng_20241025_1500\*ae072b315bc135fb4cc60cfa758b2a926bd6498f"
+  if echo "${intel_vpu_dmesg}" | grep -w "${EXPECTED_VERSION}"; then
+    echo "Test success: expected firmware version successfully loaded to NPU device!"
+  else
+    >&2 echo "Test failure: NPU not running expected version ${EXPECTED_VERSION}"
+    exit 1
+  fi
+
 id: umd/Umd
 category_id: npu
 flags: simple
@@ -416,7 +486,11 @@ plugin: resource
 _description: Creates resource for metric streamer feature support
 estimated_duration: 2s
 command:
-  if [ $(uname -r | cut -f2 -d.) -gt 8 ]; then
+  # support added in kernel version 6.9
+  MIN_VERSION=6.9
+  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
+  if [ "${result}" = "${MIN_VERSION}" ]; then
+    # indicates that the running kernel is >= 6.9
     echo "state: supported"
   else
     echo "state: unsupported"

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -1,15 +1,15 @@
-# For 1.6.0 there are known issues with the following tests
+# For 1.10.1 there are known issues with the following tests
 # so we explictly filter them out below.
 # 
-# BuffersExport.GpuZeFillToNpuZeCopy
-# BuffersExport.NpuZeFillToGpuZeCopy
-# CompilerInDriver.CreatingGraphWithNullptrInputGraphExpectFailure
-# CompilerInDriver.CreatingGraphWithZeroGraphSizeExpectFailure
-# CompilerInDriver.CreatingGraphCorrectBlobFileAndDescExpectSuccess
-# CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst
-# Sizes/PrimeBuffers.importDeviceMemory/2KB
-# Sizes/PrimeBuffers.importDeviceMemory/16MB
-# Sizes/PrimeBuffers.importDeviceMemory/255MB
+# BuffersExport.GpuZeFillToNpuZeCopy -- Also in 1.6.0
+# BuffersExport.NpuZeFillToGpuZeCopy -- Also in 1.6.0
+# Device.GetZesEngineGetActivity -- New in 1.10.1
+# CommandGraphLongThreaded.RunAllBlobsInSingleContextSimultaneously -- New in 1.10.1
+# CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst -- Also in 1.6.0
+# ImportMemoryUsingDmaHeap.AllocDeviceMemory/2KB -- Also in 1.6.0
+# ImportMemoryUsingDmaHeap.AllocDeviceMemory/16MB -- Also in 1.6.0
+# ImportMemoryUsingDmaHeap.AllocDeviceMemory/255MB -- Also in 1.6.0
+# CommandGraphLong.InferenceDeviceResetInference/add_abc -- Also in 1.6.0
 
 id: kmd/CharDevicePermissions
 category_id: npu
@@ -108,6 +108,7 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=Context.* --config=basic.yaml
 
+# Filter out known failure Device.GetZesEngineGetActivity
 id: umd/Device
 category_id: npu
 flags: simple
@@ -117,7 +118,7 @@ _summary: Device
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=Device.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Device.GetProp*:Device.GetGlobal*:Device.GetZesDevice* --config=basic.yaml
 
 id: umd/Driver
 category_id: npu
@@ -185,39 +186,18 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=FenceSync.* --config=basic.yaml
 
-id: umd/GraphNativeBase
+id: umd/GraphApi
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: GraphNativeBase
+_summary: GraphApi
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphNativeBase.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphApi.* --config=basic.yaml
 
-id: umd/GraphNativeBinary
-category_id: npu
-flags: simple
-depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: GraphNativeBinary
-estimated_duration: 2s
-command:
-  cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphNativeBinary.* --config=basic.yaml
-
-id: umd/CommandGraph
-category_id: npu
-flags: simple
-depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: CommandGraph
-estimated_duration: 2s
-command:
-  cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraph.* --config=basic.yaml
-
+# filter out known failure CommandGraphLongThreaded.RunAllBlobsInSingleContextSimultaneously
 id: umd/CommandGraphLongThreaded
 category_id: npu
 flags: simple
@@ -227,7 +207,18 @@ _summary: CommandGraphLongThreaded
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLongThreaded.None* --config=basic.yaml
+
+id: umd/ImmediateCmdList
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ImmediateCmdList
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.*:-ImmediateCmdList.MetricQuerryTest --config=basic.yaml
 
 id: umd/MemoryAllocation
 category_id: npu
@@ -262,17 +253,7 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
 
-id: umd/PrimeBuffers
-category_id: npu
-flags: simple
-depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: PrimeBuffers
-estimated_duration: 2s
-command:
-  cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=PrimeBuffers.* --config=basic.yaml
-
+# filter out known failure CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst
 id: umd/CommandQueuePriority
 category_id: npu
 flags: simple
@@ -328,6 +309,85 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
 
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/CompilerInDriverLong
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: CompilerInDriverLong
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CompilerInDriverLong.* --config=basic.yaml
+
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/CompilerInDriverWithProfiling
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: CompilerInDriverWithProfiling
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CompilerInDriverWithProfiling.* --config=basic.yaml
+
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+# filtering out known failure CommandGraphLong.InferenceDeviceResetInference/add_abc
+id: umd/CommandGraphLong
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: CommandGraphLong
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLong.*:-CommandGraphLong.Inference* --config=basic.yaml
+
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/GraphInference
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: GraphInference
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphInference.* --config=basic.yaml
+
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/GraphQueryNetwork
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: GraphQueryNetwork
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphQueryNetwork.* --config=basic.yaml
+
+# for some reason this does not appear with --gtest_list_tests but it appears when running
+# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/InferencePerformance
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: InferencePerformance
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=InferencePerformance.* --config=basic.yaml
+
 id: umd/Sizes/MemoryAllocation
 category_id: npu
 flags: simple
@@ -349,17 +409,6 @@ estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
-
-id: umd/Sizes/PrimeBuffers
-category_id: npu
-flags: simple
-depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: Sizes/PrimeBuffers
-estimated_duration: 2s
-command:
-  cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
 
 id: metric_streamer
 category_id: npu
@@ -412,15 +461,15 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=MetricQuery.* --config=basic.yaml
 
-id: umd/MetricQueryCopyEngine
+id: umd/ImmediateCmdList.MetricQuerryTest
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires:
   executable.name == 'intel-npu-driver.npu-umd-test'
   metric_streamer.state == 'supported'
-_summary: MetricQueryCopyEngine
+_summary: ImmediateCmdLIst.MetricQuerryTest
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.MetricQuerryTest --config=basic.yaml

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -35,331 +35,331 @@ id: umd/Umd
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Umd
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Umd.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Umd.* --config=basic.yaml
 
 id: umd/Command
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Command
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Command.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Command.* --config=basic.yaml
 
 id: umd/CommandTimestamp
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandTimestamp
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandTimestamp.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandTimestamp.* --config=basic.yaml
 
 id: umd/CommandCopy
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandCopy
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandCopy.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandCopy.* --config=basic.yaml
 
 id: umd/CommandBarrier
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandBarrier
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandBarrier.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandBarrier.* --config=basic.yaml
 
 id: umd/CommandStress
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandStress
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandStress.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandStress.* --config=basic.yaml
 
 id: umd/Context
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Context
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Context.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Context.* --config=basic.yaml
 
 id: umd/Device
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Device
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Device.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Device.* --config=basic.yaml
 
 id: umd/Driver
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Driver
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Driver.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Driver.* --config=basic.yaml
 
 id: umd/Event
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Event
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Event.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Event.* --config=basic.yaml
 
 id: umd/EventSync
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: EventSync
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=EventSync.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=EventSync.* --config=basic.yaml
 
 id: umd/EventPool
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: EventPool
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=EventPool.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=EventPool.* --config=basic.yaml
 
 id: umd/Fence
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Fence
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Fence.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Fence.* --config=basic.yaml
 
 id: umd/FenceSync
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Fence Sync
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=FenceSync.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=FenceSync.* --config=basic.yaml
 
 id: umd/GraphNativeBase
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: GraphNativeBase
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=GraphNativeBase.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphNativeBase.* --config=basic.yaml
 
 id: umd/GraphNativeBinary
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: GraphNativeBinary
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=GraphNativeBinary.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphNativeBinary.* --config=basic.yaml
 
 id: umd/CommandGraph
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandGraph
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandGraph.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraph.* --config=basic.yaml
 
 id: umd/CommandGraphLongThreaded
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandGraphLongThreaded
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
 
 id: umd/MemoryAllocation
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: MemoryAllocation
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryAllocation.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MemoryAllocation.* --config=basic.yaml
 
 id: umd/MemoryExecution
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: MemoryExecution
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryExecution.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MemoryExecution.* --config=basic.yaml
 
 id: umd/MemoryAllocationThreaded
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: MemoryAllocationThreaded
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MemoryAllocationThreaded.* --config=basic.yaml
 
 id: umd/PrimeBuffers
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: PrimeBuffers
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=PrimeBuffers.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=PrimeBuffers.* --config=basic.yaml
 
 id: umd/CommandQueuePriority
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandQueuePriority
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandQueuePriority.create*:CommandQueuePriority.executeCopy* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandQueuePriority.create*:CommandQueuePriority.executeCopy* --config=basic.yaml
 
 id: umd/CommandMemoryFill
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandMemoryFill
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandMemoryFill.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandMemoryFill.* --config=basic.yaml
 
 id: umd/MultiContext
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: MultiContext
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MultiContext.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MultiContext.* --config=basic.yaml
 
 id: umd/CommandCopyPerf
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: CommandCopyPerf
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=CommandCopyPerf.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandCopyPerf.* --config=basic.yaml
 
 id: umd/SystemToSystem/CommandCopyFlag
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: SystemToSystem/CommandCopyFlag
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
 
 id: umd/Sizes/MemoryAllocation
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Sizes/MemoryAllocation
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
 
 id: umd/Sizes/MemoryExecution
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Sizes/MemoryExecution
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
 
 id: umd/Sizes/PrimeBuffers
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.vpu-umd-test'
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
 _summary: Sizes/PrimeBuffers
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/PrimeBuffers.export* --config=basic.yaml
 
 id: metric_streamer
 category_id: npu
@@ -378,49 +378,49 @@ category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires:
-  executable.name == 'intel-npu-driver.vpu-umd-test'
+  executable.name == 'intel-npu-driver.npu-umd-test'
   metric_streamer.state == 'supported'
 _summary: Metric
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=Metric.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Metric.* --config=basic.yaml
 
 id: umd/MetricQueryPool
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires:
-  executable.name == 'intel-npu-driver.vpu-umd-test'
+  executable.name == 'intel-npu-driver.npu-umd-test'
   metric_streamer.state == 'supported'
 _summary: MetricQueryPool
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQueryPool.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MetricQueryPool.* --config=basic.yaml
 
 id: umd/MetricQuery
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires:
-  executable.name == 'intel-npu-driver.vpu-umd-test'
+  executable.name == 'intel-npu-driver.npu-umd-test'
   metric_streamer.state == 'supported'
 _summary: MetricQuery
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQuery.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MetricQuery.* --config=basic.yaml
 
 id: umd/MetricQueryCopyEngine
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires:
-  executable.name == 'intel-npu-driver.vpu-umd-test'
+  executable.name == 'intel-npu-driver.npu-umd-test'
   metric_streamer.state == 'supported'
 _summary: MetricQueryCopyEngine
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.vpu-umd-test -S --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MetricQueryCopyEngine.* --config=basic.yaml

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+INSTALL_DIR="${SNAP_DATA}"/intel/vpu
+mkdir -p "${INSTALL_DIR}"
+
+# Note that the -f flag is required here because during a snap refresh
+# SNAP_DATA is copied from the previous snap revision to the new one,
+# so below we are actually overwriting the firmware files that have
+# already been copied over, and need the -f flag to allow this.
+cp -avf "${SNAP}"/lib/firmware/updates/intel/vpu/* "${INSTALL_DIR}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,7 +78,6 @@ parts:
     override-pull: |
       craftctl default
       git submodule update --init --recursive
-      git lfs pull
       craftctl set version="$(git describe --tags | tr -d 'v')"
     build-packages:
       - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: intel-npu-driver
 base: core24
-version: '1.6.0'
 summary: User Mode Driver with Compiler Software for the Intel® NPU
 description: |
   User mode driver (UMD) with compiler for the Intel® NPU software stack.
@@ -13,6 +12,7 @@ description: |
   For more info, see https://github.com/intel/linux-npu-driver
 grade: devel
 confinement: strict
+adopt-info: npu-driver
 
 slots:
   intel-npu:
@@ -51,8 +51,8 @@ hooks:
       - intel-npu-fw
 
 apps:
-  vpu-umd-test:
-    command: usr/bin/vpu-umd-test
+  npu-umd-test:
+    command: usr/bin/npu-umd-test
     plugs: [intel-npu-plug]
 
   load-npu-firmware:
@@ -70,15 +70,16 @@ parts:
   npu-driver:
     source-type: git
     source: https://github.com/intel/linux-npu-driver.git
-    source-tag: v1.6.0
+    source-tag: v1.10.1
     plugin: cmake
     cmake-parameters:
-      - -DENABLE_VPUX_COMPILER_BUILD=ON
+      - -DENABLE_NPU_COMPILER_BUILD=ON
       - -DCMAKE_INSTALL_PREFIX=/usr
     override-pull: |
       craftctl default
       git submodule update --init --recursive
       git lfs pull
+      craftctl set version="$(git describe --tags | tr -d 'v')"
     build-packages:
       - build-essential
       - git-lfs


### PR DESCRIPTION
The primary thing this PR does is bump the upstream version from 1.6.0 to 1.10.1. Along the way this required other related changes:

* Update checkbox tests and test results in README
* Properly handle installation of new firmware during a snap refresh using a `post-refresh` hook
* Update name of validation tool for consistency with upstream (`vpu-umd-test` -> `npu-umd-test`)

Testing environments:
* hercules (meteor lake) running 24.04 and 24.10
* tucano (lunar lake) running 24.04 and 24.10

I also tested the GIMP plugins against the new NPU driver snap, and confirmed that the new NPU driver [fixes bugs on Lunar Lake](https://github.com/intel/openvino-ai-plugins-gimp/issues/158).