### PR TITLE
Bump version to 1.16.0

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -74,7 +74,7 @@ test_data:
     # Build and install checkbox-npu snap
     ssh ubuntu@$DEVICE_IP '
       cd ~ubuntu/intel-npu-driver-snap/checkbox
-      sudo snap install checkbox22
+      sudo snap install checkbox24
       snapcraft
       sudo snap install --dangerous --classic ./checkbox-npu_*_amd64.snap
     '

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${GITHUB_WORKSPACE}/job.yaml
+          job-path: ${{ github.workspace }}/job.yaml

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We have validated the snap using the [`npu-umd-test` user mode driver validation
 | 22.04 | 5.15 | :x:                | N/A            |
 | 24.04 | 6.8  | :white_check_mark: | 194/209 passed |
 | 24.10 | 6.11 | :white_check_mark: | 200/209 passed |
+| 25.04 | 6.14 | :white_check_mark: | 200/209 passed |
 
 Skipped tests on kernel 6.8 and lower only:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ We have validated the snap using the [`npu-umd-test` user mode driver validation
 | Host OS | Kernel Version | NPU Kernel Driver Support | Test Results |
 | ----- | :--: | :----------------: | :------------: |
 | 22.04 | 5.15 | :x:                | N/A            |
-| 24.04 | 6.8  | :white_check_mark: | 185/200 passed |
-| 24.10 | 6.11 | :white_check_mark: | 191/200 passed |
+| 24.04 | 6.8  | :white_check_mark: | 194/209 passed |
+| 24.10 | 6.11 | :white_check_mark: | 200/209 passed |
 
 Skipped tests on kernel 6.8 and lower only:
 
@@ -27,10 +27,21 @@ Skipped tests on kernel 6.8 and lower only:
 Skipped tests common across all host OS and kernel versions:
 
 - GPU driver not present (2 tests)
-- DMA capabilities require tests to be run as root (3 tests)
+- DMA capabilities require access to `/dev/dma_heap/system` (3 tests)
 - Device GetZesEngineGetActivity test requires access to a file in `/sys/devices` for monitoring NPU utilization - this feature is considered non-critical (1 test)
-- Command graph long and command graph long threaded under investigation (2 tests)
+- Command graph long under investigation (1 tests)
 - Command queue priority under investigation (1 test)
+- Model cache awaiting instructions from upstream developers (1 test)
+
+### Known issues
+
+There is an issue on older kernel versions (e.g. 6.8) where messages like the following may flood the kernel logs:
+
+```
+[drm] *ERROR* ivpu_ipc_send_receive_internal(): IPC receive failed: type VPU_JSM_MSG_SSID_RELEASE, ret -74]
+```
+
+These messages can be safely ignored and should not affect NPU funtionality.
 
 ## Instructions for building and running the snap
 

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -6,7 +6,7 @@ This directory contains the Checkbox NPU Provider, including the snap recipe for
 
 ```
 sudo snap install --classic snapcraft
-sudo snap install checkbox22
+sudo snap install checkbox24
 lxd init --auto
 git clone https://github.com/canonical/intel-npu-driver-snap.git
 cd intel-npu-driver-snap/checkbox

--- a/checkbox/bin/checkbox-cli-wrapper
+++ b/checkbox/bin/checkbox-cli-wrapper
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # wrapper around the checkbox-cli
-exec /snap/checkbox22/current/bin/checkbox-cli "$@"
+exec /snap/checkbox24/current/bin/checkbox-cli "$@"

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -26,4 +26,4 @@ cd $HOME/snap/intel-npu-driver/current
 mkdir -p models/add_abc
 curl -s -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
 touch models/add_abc/add_abc.bin
-curl -s -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.10.1/validation/umd-test/configs/basic.yaml
+curl -s -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.16.0/validation/umd-test/configs/basic.yaml

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -20,7 +20,7 @@ esac
 
 RUNTIME=/snap/checkbox24/current
 if [ ! -d "$RUNTIME" ]; then
-    echo "You need to install the checkbox22 snap."
+    echo "You need to install the checkbox24 snap."
     echo ""
     echo "You can do this with this command:"
     echo "snap install checkbox24"

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -34,7 +34,6 @@ export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepo
 export PATH="$SNAP/usr/sbin:$SNAP/sbin:$SNAP/usr/bin:$SNAP/bin:/snap/bin:$PATH"
 export ALSA_CONFIG_PATH=$SNAP/usr/share/alsa/alsa.conf:$SNAP/usr/share/alsa/pcm/default.conf
 export PYTHONPATH="$SNAP/lib:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
-export PATH="$SNAP/providers/checkbox-provider-npu/bin/:$PATH"
 
 if [ -e $RUNTIME/wrapper_common_classic ]; then
   . $RUNTIME/wrapper_common_classic
@@ -42,5 +41,9 @@ else
   echo "ERROR: no $RUNTIME/wrapper_common_classic found"
   exit 0
 fi
+# Ensure python3 interpreter from provider snap is used rather than the one from
+# the checkbox24 snap. This enables better host OS support by ensuring that the
+# python interpreter is using libs from core24 rather than the host.
+export PATH="$SNAP/usr/bin:$SNAP/providers/checkbox-provider-npu/bin/:$PATH"
 
 exec "$@"

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -18,12 +18,12 @@ esac
 # Launcher common exports for any checkbox app #
 ################################################
 
-RUNTIME=/snap/checkbox22/current
+RUNTIME=/snap/checkbox24/current
 if [ ! -d "$RUNTIME" ]; then
     echo "You need to install the checkbox22 snap."
     echo ""
     echo "You can do this with this command:"
-    echo "snap install checkbox22"
+    echo "snap install checkbox24"
     exit 1
 fi
 

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -1,15 +1,15 @@
-# For 1.10.1 there are known issues with the following tests
-# so we explictly filter them out below.
-# 
-# BuffersExport.GpuZeFillToNpuZeCopy -- Also in 1.6.0
-# BuffersExport.NpuZeFillToGpuZeCopy -- Also in 1.6.0
-# Device.GetZesEngineGetActivity -- New in 1.10.1
-# CommandGraphLongThreaded.RunAllBlobsInSingleContextSimultaneously -- New in 1.10.1
-# CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst -- Also in 1.6.0
-# ImportMemoryUsingDmaHeap.AllocDeviceMemory/2KB -- Also in 1.6.0
-# ImportMemoryUsingDmaHeap.AllocDeviceMemory/16MB -- Also in 1.6.0
-# ImportMemoryUsingDmaHeap.AllocDeviceMemory/255MB -- Also in 1.6.0
-# CommandGraphLong.InferenceDeviceResetInference/add_abc -- Also in 1.6.0
+# For 1.16.0 there are known tests that we do not run in the test plan
+#
+# Device.GetZesEngineGetActivity -- No sysfs access for NPU activity data
+# ExternalMemoryZe.GpuZeFillToNpuZeCopy -- No GPU support for test
+# ExternalMemoryZe.NpuZeFillToGpuZeCopy -- No GPU support for test
+# ModelCacheTest.CheckIfModelIsCachedWithBuildLog -- Requires cached model, awaiting upstream docs
+# CommandQueuePriority.executeManyLowPriorityJobsExpectHighPriorityJobCompletesFirst -- known failure since 1.6.0
+# ExternalMemoryDmaHeap.DmaHeapToNpu/2KB -- requires access to /dev/dma_heap/system
+# ExternalMemoryDmaHeap.DmaHeapToNpu/16MB -- requires access to /dev/dma_heap/system
+# ExternalMemoryDmaHeap.DmaHeapToNpu/255MB -- requires access to /dev/dma_heap/system
+# CommandGraphLong.InferenceDeviceResetInference/add_abc -- known failure
+#
 
 id: kmd/CharDevicePermissions
 category_id: npu
@@ -31,36 +31,6 @@ command:
   fi
   echo "Test success: user has read and write access to /dev/accel/accel0"
 
-id: dmesg_logs_firmware_version
-category_id: npu
-plugin: resource
-_description: Creates resource for firwmare version logging support in dmesg
-estimated_duration: 2s
-command:
-  # support added in kernel version 6.8
-  MIN_VERSION=6.8
-  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
-  if [ "${result}" = "${MIN_VERSION}" ]; then
-    # indicates that the running kernel is >= 6.8
-    echo "state: supported"
-  else
-    echo "state: unsupported"
-  fi
-
-id: npu_type
-category_id: npu
-plugin: resource
-_description: Creates resource for type of NPU
-estimated_duration: 2s
-command:
-  if lspci -nn | grep "Meteor Lake NPU"; then
-    echo "name: meteor_lake"
-  elif lspci -nn | grep "Lunar Lake NPU"; then
-    echo "name: lunar_lake"
-  elif lspci -nn | grep "Arrow Lake NPU"; then
-    echo "name: arrow_lake"
-  fi
-
 id: kmd/firmware_version_meteor_and_arrow_lake
 category_id: npu
 flags: simple
@@ -73,7 +43,8 @@ command:
   printf "[INFO]: dmesg logs for intel_vpu kernel module:\n $(sudo dmesg | grep intel_vpu)"
   intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
   # Expected version strings: https://github.com/intel/linux-npu-driver/releases/tag/v1.10.1
-  EXPECTED_VERSION="20241025\*MTL_CLIENT_SILICON-release\*1830\*ci_tag_ud202444_vpu_rc_20241025_1830\*ae072b315bc"
+  # Don't forget to escape special characters (asterix) in the following string
+  EXPECTED_VERSION="20250306\*MTL_CLIENT_SILICON-release\*1130\*ci_tag_ud202512_vpu_rc_20250306_1130\*5064b5debc3"
   if echo "${intel_vpu_dmesg}" | grep -w "${EXPECTED_VERSION}"; then
     echo "Test success: expected firmware version successfully loaded to NPU device!"
   else
@@ -93,7 +64,8 @@ command:
   printf "[INFO]: dmesg logs for intel_vpu kernel module:\n $(sudo dmesg | grep intel_vpu)"
   intel_vpu_dmesg=$(sudo dmesg | grep "Firmware: intel/vpu" | tail -n1)
   # Expected version strings: https://github.com/intel/linux-npu-driver/releases/tag/v1.10.1
-  EXPECTED_VERSION="Oct 25 2024\*NPU40xx\*ci_tag_ud202444_vpu_eng_20241025_1500\*ae072b315bc135fb4cc60cfa758b2a926bd6498f"
+  # Don't forget to escape special characters (asterix) in the following string
+  EXPECTED_VERSION="Mar  6 2025\*NPU40xx\*ci_tag_ud202512_vpu_rc_20250306_1130\*5064b5debc377e1c4b74f69dc14e2e536dba393d"
   if echo "${intel_vpu_dmesg}" | grep -w "${EXPECTED_VERSION}"; then
     echo "Test success: expected firmware version successfully loaded to NPU device!"
   else
@@ -188,7 +160,7 @@ _summary: Device
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=Device.GetProp*:Device.GetGlobal*:Device.GetZesDevice* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=Device.GetProp*:Device.GetGlobal*:Device.GetZesDevice*:Device.Verify* --config=basic.yaml
 
 id: umd/Driver
 category_id: npu
@@ -200,6 +172,18 @@ estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=Driver.* --config=basic.yaml
+
+id: umd/DriverCache
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: DriverCache
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  sed 's|graph_execution|driver_cache|' basic.yaml > driver_cache.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=DriverCache.* --config=driver_cache.yaml
 
 id: umd/Event
 category_id: npu
@@ -234,6 +218,18 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=EventPool.* --config=basic.yaml
 
+# Not running ExternalMemoryZe.* due to need for GPU support
+id: umd/ExternalMemory
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ExternalMemory
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=ExternalMemory.* --config=basic.yaml
+
 id: umd/Fence
 category_id: npu
 flags: simple
@@ -256,6 +252,17 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=FenceSync.* --config=basic.yaml
 
+id: umd/GraphApiBase
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: GraphApiBase
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=GraphApiBase.* --config=basic.yaml
+
 id: umd/GraphApi
 category_id: npu
 flags: simple
@@ -267,17 +274,8 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=GraphApi.* --config=basic.yaml
 
-# filter out known failure CommandGraphLongThreaded.RunAllBlobsInSingleContextSimultaneously
-id: umd/CommandGraphLongThreaded
-category_id: npu
-flags: simple
-depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: CommandGraphLongThreaded
-estimated_duration: 2s
-command:
-  cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLongThreaded.None* --config=basic.yaml
+# Skipping ModelCacheTest.CheckIfModelIsCachedWithBuildLog for now while we
+# await for instructions from upstream
 
 id: umd/ImmediateCmdList
 category_id: npu
@@ -289,6 +287,30 @@ estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.*:-ImmediateCmdList.MetricQuerryTest --config=basic.yaml
+
+# note, the ZeInitDrivers tests must be run in serial
+id: umd/ZeInitDrivers.FailWithoutInit
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ZeInitDrivers.FailWithoutInit
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -I zeInitDrivers.FailWithoutInit
+
+# note, the ZeInitDrivers tests must be run in serial
+id: umd/ZeInitDrivers.InitializeAndExecuteCopyCommand
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ZeInitDrivers.InitializeAndExecuteCopyCommand
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -I zeInitDrivers.InitializeAndExecuteCopyCommand
 
 id: umd/MemoryAllocation
 category_id: npu
@@ -357,6 +379,17 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=MultiContext.* --config=basic.yaml
 
+id: umd/MultiContextGraph
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: MultiContextGraph
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MultiContextGraph.* --config=basic.yaml
+
 id: umd/CommandCopyPerf
 category_id: npu
 flags: simple
@@ -379,8 +412,9 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=SystemToSystem/CommandCopyFlag.* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+# Skipping three ExternalMemoryDmaHeap.* tests due to needing access
+# to /dev/dma_heap/system
+
 id: umd/CompilerInDriverLong
 category_id: npu
 flags: simple
@@ -392,8 +426,6 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=CompilerInDriverLong.* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
 id: umd/CompilerInDriverWithProfiling
 category_id: npu
 flags: simple
@@ -405,8 +437,6 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=CompilerInDriverWithProfiling.* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
 # filtering out known failure CommandGraphLong.InferenceDeviceResetInference/add_abc
 id: umd/CommandGraphLong
 category_id: npu
@@ -419,8 +449,17 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLong.*:-CommandGraphLong.Inference* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
+id: umd/CommandGraphLongThreaded
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: CommandGraphLongThreaded
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=CommandGraphLongThreaded.* --config=basic.yaml
+
 id: umd/GraphInference
 category_id: npu
 flags: simple
@@ -432,8 +471,6 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=GraphInference.* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
 id: umd/GraphQueryNetwork
 category_id: npu
 flags: simple
@@ -445,8 +482,6 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=GraphQueryNetwork.* --config=basic.yaml
 
-# for some reason this does not appear with --gtest_list_tests but it appears when running
-# intel-npu-driver.npu-umd-test --config=basic.yaml 2> /dev/null | grep "test* from"
 id: umd/InferencePerformance
 category_id: npu
 flags: simple
@@ -458,43 +493,64 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=InferencePerformance.* --config=basic.yaml
 
-id: umd/Sizes/MemoryAllocation
+# note, the ZeInit tests must be run in serial
+id: umd/ZeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/0
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: Sizes/MemoryAllocation
+_summary: ZeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/0
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/MemoryAllocation.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -I zeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/0
 
-id: umd/Sizes/MemoryExecution
+# note, the ZeInit tests must be run in serial
+id: umd/ZeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/1
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
 requires: executable.name == 'intel-npu-driver.npu-umd-test'
-_summary: Sizes/MemoryExecution
+_summary: ZeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/1
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=Sizes/MemoryExecution.* --config=basic.yaml
+  intel-npu-driver.npu-umd-test -I zeInit.CallzeInitThenzeInitDriversThenExecuteCopyCommand/1
 
-id: metric_streamer
+# note, the ZeInit tests must be run in serial
+id: umd/ZeInit.CallzeInitThenExecuteCopyCommand/0
 category_id: npu
-plugin: resource
-_description: Creates resource for metric streamer feature support
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ZeInit.CallzeInitThenExecuteCopyCommand/0
 estimated_duration: 2s
 command:
-  # support added in kernel version 6.9
-  MIN_VERSION=6.9
-  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
-  if [ "${result}" = "${MIN_VERSION}" ]; then
-    # indicates that the running kernel is >= 6.9
-    echo "state: supported"
-  else
-    echo "state: unsupported"
-  fi
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -I zeInit.CallzeInitThenExecuteCopyCommand/0
+
+# note, the ZeInit tests must be run in serial
+id: umd/ZeInit.CallzeInitThenExecuteCopyCommand/1
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: ZeInit.CallzeInitThenExecuteCopyCommand/1
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -I zeInit.CallzeInitThenExecuteCopyCommand/1
+
+id: umd/MultiMemoryExecution
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires: executable.name == 'intel-npu-driver.npu-umd-test'
+_summary: MultiMemoryExecution
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=MultiMemoryExecution.* --config=basic.yaml
 
 id: umd/Metric
 category_id: npu

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -286,7 +286,20 @@ _summary: ImmediateCmdList
 estimated_duration: 2s
 command:
   cd $HOME/snap/intel-npu-driver/current
-  intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.*:-ImmediateCmdList.MetricQuerryTest --config=basic.yaml
+  intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.Create*:ImmediateCmdList.Get* --config=basic.yaml
+
+id: umd/ImmediateCmdList.FillCopyUsingBarriers
+category_id: npu
+flags: simple
+depends: kmd/CharDevicePermissions
+requires:
+  executable.name == 'intel-npu-driver.npu-umd-test'
+  ivpu_bo_create.state == 'supported'
+_summary: ImmediateCmdList.FillCopyUsingBarriers
+estimated_duration: 2s
+command:
+  cd $HOME/snap/intel-npu-driver/current
+  intel-npu-driver.npu-umd-test -S --gtest_filter=ImmediateCmdList.FillCopyUsingBarriers --config=basic.yaml
 
 # note, the ZeInitDrivers tests must be run in serial
 id: umd/ZeInitDrivers.FailWithoutInit
@@ -361,7 +374,9 @@ id: umd/CommandMemoryFill
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
+requires:
+  executable.name == 'intel-npu-driver.npu-umd-test'
+  ivpu_bo_create.state == 'supported'
 _summary: CommandMemoryFill
 estimated_duration: 2s
 command:
@@ -430,7 +445,9 @@ id: umd/CompilerInDriverWithProfiling
 category_id: npu
 flags: simple
 depends: kmd/CharDevicePermissions
-requires: executable.name == 'intel-npu-driver.npu-umd-test'
+requires:
+  executable.name == 'intel-npu-driver.npu-umd-test'
+  ivpu_bo_create.state == 'supported'
 _summary: CompilerInDriverWithProfiling
 estimated_duration: 2s
 command:

--- a/checkbox/checkbox-provider-npu/units/jobs.pxu
+++ b/checkbox/checkbox-provider-npu/units/jobs.pxu
@@ -218,7 +218,9 @@ command:
   cd $HOME/snap/intel-npu-driver/current
   intel-npu-driver.npu-umd-test -S --gtest_filter=EventPool.* --config=basic.yaml
 
-# Not running ExternalMemoryZe.* due to need for GPU support
+# Not running ExternalMemoryZe.* (which would usually run next when
+# all tests are run without gtest filters) due to need for GPU support
+
 id: umd/ExternalMemory
 category_id: npu
 flags: simple

--- a/checkbox/checkbox-provider-npu/units/resource.pxu
+++ b/checkbox/checkbox-provider-npu/units/resource.pxu
@@ -17,7 +17,7 @@ command:
 id: npu_type
 category_id: npu
 plugin: resource
-_description: Creates resource for type of NPU
+_description: Detects NPU type, if available, on the platform
 estimated_duration: 2s
 command:
   if lspci -nn | grep "Meteor Lake NPU"; then

--- a/checkbox/checkbox-provider-npu/units/resource.pxu
+++ b/checkbox/checkbox-provider-npu/units/resource.pxu
@@ -1,0 +1,45 @@
+id: dmesg_logs_firmware_version
+category_id: npu
+plugin: resource
+_description: Creates resource for firwmare version logging support in dmesg
+estimated_duration: 2s
+command:
+  # support added in kernel version 6.8
+  MIN_VERSION=6.8
+  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
+  if [ "${result}" = "${MIN_VERSION}" ]; then
+    # indicates that the running kernel is >= 6.8
+    echo "state: supported"
+  else
+    echo "state: unsupported"
+  fi
+
+id: npu_type
+category_id: npu
+plugin: resource
+_description: Creates resource for type of NPU
+estimated_duration: 2s
+command:
+  if lspci -nn | grep "Meteor Lake NPU"; then
+    echo "name: meteor_lake"
+  elif lspci -nn | grep "Lunar Lake NPU"; then
+    echo "name: lunar_lake"
+  elif lspci -nn | grep "Arrow Lake NPU"; then
+    echo "name: arrow_lake"
+  fi
+
+id: metric_streamer
+category_id: npu
+plugin: resource
+_description: Creates resource for metric streamer feature support
+estimated_duration: 2s
+command:
+  # support added in kernel version 6.9
+  MIN_VERSION=6.9
+  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
+  if [ "${result}" = "${MIN_VERSION}" ]; then
+    # indicates that the running kernel is >= 6.9
+    echo "state: supported"
+  else
+    echo "state: unsupported"
+  fi

--- a/checkbox/checkbox-provider-npu/units/resource.pxu
+++ b/checkbox/checkbox-provider-npu/units/resource.pxu
@@ -43,3 +43,19 @@ command:
   else
     echo "state: unsupported"
   fi
+
+id: ivpu_bo_create
+category_id: npu
+plugin: resource
+_description: Creates resource for DRM_IOCTL_IVPU_BO_CREATE support
+estimated_duration: 2s
+command:
+  # support added in kernel version 6.6
+  MIN_VERSION=6.6
+  result=$(printf "${MIN_VERSION}\n$(uname -r | cut -f1-2 -d.)\n" | sort -V | head -n1)
+  if [ "${result}" = "${MIN_VERSION}" ]; then
+    # indicates that the running kernel is >= 6.6
+    echo "state: supported"
+  else
+    echo "state: unsupported"
+  fi

--- a/checkbox/checkbox-provider-npu/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-npu/units/test-plan.pxu
@@ -10,4 +10,4 @@ bootstrap_include:
     com.canonical.certification::dmesg_logs_firmware_version
     com.canonical.certification::npu_type
     com.canonical.certification::metric_streamer
-
+    com.canonical.certification::ivpu_bo_create

--- a/checkbox/checkbox-provider-npu/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-npu/units/test-plan.pxu
@@ -7,4 +7,7 @@ include:
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
+    com.canonical.certification::dmesg_logs_firmware_version
+    com.canonical.certification::npu_type
+    com.canonical.certification::metric_streamer
 

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -52,6 +52,14 @@ parts:
     build-snaps:
       - checkbox-provider-tools
       - checkbox24
+    build-attributes:
+      - enable-patchelf
+      # See: https://snapcraft.io/docs/linters-classic
+      # This patches the python interpreter to allow use of the dynamic linker from core24
+    stage-packages:
+      - python3-minimal
+      - python3.12-minimal
+      # This provides a python interpreter for checkbox to use that works properly with classic confinement
     override-build: |
       for path in $(find "/snap/checkbox24/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       checkbox-provider-tools validate

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ version: '1.0.0'
 confinement: classic
 grade: stable
 
-base: core22
+base: core24
 
 # Here are the available applications of the NPU checkbox provider snap
 # To run : snap run checkbox-npu.<app>
@@ -51,9 +51,9 @@ parts:
     source-type: local
     build-snaps:
       - checkbox-provider-tools
-      - checkbox22
+      - checkbox24
     override-build: |
-      for path in $(find "/snap/checkbox22/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      for path in $(find "/snap/checkbox24/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
       checkbox-provider-tools validate
       checkbox-provider-tools build
       checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-npu --root="$SNAPCRAFT_PART_INSTALL"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
   npu-driver:
     source-type: git
     source: https://github.com/intel/linux-npu-driver.git
-    source-tag: v1.10.1
+    source-tag: v1.16.0
     plugin: cmake
     cmake-parameters:
       - -DENABLE_NPU_COMPILER_BUILD=ON
@@ -103,7 +103,8 @@ lint:
       # shared object, but rather dynamically
       # loaded by apps.
       - usr/lib/x86_64-linux-gnu/libze_validation_layer*
-      - usr/lib/x86_64-linux-gnu/libze_intel_vpu*
+      - usr/lib/x86_64-linux-gnu/libze_intel_npu*
+      - usr/lib/x86_64-linux-gnu/libze_tracing_layer*
       - usr/lib/x86_64-linux-gnu/libnpu_driver_compiler*
       - usr/lib/x86_64-linux-gnu/libtbb*
       - usr/lib/x86_64-linux-gnu/libhwloc*


### PR DESCRIPTION
In addition to bumping to the latest upstream version I also made a few improvements to the checkbox provider:

* Bump to `core24`
* Split out `resources` into dedicated `resource.pxu` file

Note that some of the validation is ongoing on Lunar Lake and Arrow Lake and different OS releases. I will post results once that is complete and update the README if needed.