### PR TITLE
Promote grade to stable based on support agreement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   the oneAPI Level-Zero and UMD with compiler libraries. It also distributes
   an app for validating the UMD.
   For more info, see https://github.com/intel/linux-npu-driver
-grade: devel
+grade: stable
 confinement: strict
 adopt-info: npu-driver
 


### PR DESCRIPTION
Until now the snap has been published in `edge` and `beta` only, this PR will enable us to now also promote to `candidate` and `stable`.