### PR TITLE
Refactor integration testing

### DIFF
--- a/.github/testflinger/check-npu-fw.sh
+++ b/.github/testflinger/check-npu-fw.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-set -e
 fw_search_path=$(sudo cat /sys/module/firmware_class/parameters/path)
 echo "[INFO]: fw_search_path: ${fw_search_path}"
 echo "[INFO]: $(snap services intel-npu-driver.load-npu-firmware)"

--- a/.github/testflinger/check-npu-fw.sh
+++ b/.github/testflinger/check-npu-fw.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+set -e
+fw_search_path=$(sudo cat /sys/module/firmware_class/parameters/path)
+echo "[INFO]: fw_search_path: ${fw_search_path}"
+echo "[INFO]: $(snap services intel-npu-driver.load-npu-firmware)"
+echo "[INFO]: $(sudo snap logs intel-npu-driver.load-npu-firmware)"
+if [ -z "${fw_search_path}" ]; then
+  >&2 echo "Test error: Firmware search path not updated."
+  exit 1
+fi
+echo "Checking for firmware in the expected path ${fw_search_path}/intel/vpu"
+ls "${fw_search_path}"/intel/vpu/ | grep ".*.bin$"
+echo "Test success: Found .bin file(s) in the expected path."

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -34,16 +34,27 @@ test_data:
     echo "[INFO]: Sleeping for 60 seconds to ensure the firmware search path is updated."
     sleep 60
 
-    _run attachments/test/check-npu-fw.sh
+    _put attachments/test/check-npu-fw.sh :/home/ubuntu/check-npu-fw.sh
+    _run bash check-npu-fw.sh
 
     _run sudo snap install checkbox24
-    _run sudo snap install --dangerous --classic attachments/test/checkbox-npu.snap
+    _put attachments/test/checkbox-npu.snap :/home/ubuntu/checkbox-npu.snap
+    _run sudo snap install --dangerous --classic /home/ubuntu/checkbox-npu.snap
 
-    _run sudo usermod -a -G render $USER
+    _run sudo usermod -a -G render ubuntu
     _run sudo chown root:render /dev/accel/accel0
     _run sudo chmod g+rw /dev/accel/accel0
 
+    _run sudo apt-get install -y curl
     _run checkbox-npu.install-full-deps
+    echo
+    echo "========= Checkbox NPU ========="
+    echo "====== DEVICE KERNEL INFO ======"
+    echo
+    _run uname -a
+    echo
+    echo "==========================================="
+    echo
     _run checkbox-npu.test-runner-automated
 
     # Upgrade apt packages, primarily to revalidate against a newer kernel
@@ -53,4 +64,12 @@ test_data:
     wait_for_ssh --allow-degraded
 
     _run checkbox-npu.install-full-deps
+    echo
+    echo "========= Checkbox NPU ========="
+    echo "====== DEVICE KERNEL INFO ======"
+    echo
+    _run uname -a
+    echo
+    echo "==========================================="
+    echo
     _run checkbox-npu.test-runner-automated

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -6,7 +6,8 @@ test_data:
   attachments:
     - local: REPLACE_ATTACHMENT
       agent: "checkbox-npu.snap"
-    - local: "check-npu-fw.sh"
+    - local: ".github/testflinger/check-npu-fw.sh"
+      agent: "check-npu-fw.sh"
   test_cmds: |
 
     set -x
@@ -41,6 +42,15 @@ test_data:
     _run sudo usermod -a -G render $USER
     _run sudo chown root:render /dev/accel/accel0
     _run sudo chmod g+rw /dev/accel/accel0
+
+    _run checkbox-npu.install-full-deps
+    _run checkbox-npu.test-runner-automated
+
+    # Upgrade apt packages, primarily to revalidate against a newer kernel
+    _run sudo apt-get update
+    _run sudo apt-get -y upgrade
+    _run sudo reboot
+    wait_for_ssh --allow-degraded
 
     _run checkbox-npu.install-full-deps
     _run checkbox-npu.test-runner-automated

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -56,8 +56,8 @@ test_data:
     #
     _run sudo bash run-checkbox-npu.sh
 
-    _run sudo apt-get update
-    _run sudo apt-get -y upgrade
+    _run sudo apt update
+    _run sudo apt -y upgrade
     _run sudo reboot
     wait_for_ssh --allow-degraded
 

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,85 +1,46 @@
 job_queue: REPLACE_QUEUE
 output_timeout: 7200
 provision_data:
-  REPLACE_PROVISION_DATA
+  url: REPLACE_IMAGE_URL
 test_data:
+  attachments:
+    - local: REPLACE_ATTACHMENT
+      agent: "checkbox-npu.snap"
+    - local: "check-npu-fw.sh"
   test_cmds: |
 
-    # Exit immediately if a test fails
-    set -e
+    set -x
 
-    # Clone repo from appropriate branch/commit.
-    ssh ubuntu@$DEVICE_IP '
-      sudo DEBIAN_FRONTEND=noninteractive apt update
-      sudo DEBIAN_FRONTEND=noninteractive apt -y upgrade
-      sudo DEBIAN_FRONTEND=noninteractive apt -y install git curl
-    '
+    # retrieve the tools installer
+    curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
+    # install the scriptlets and other tools on the agent and the device, as necessary
+    export TOOLS_PATH=tools
+    source install_tools.sh $TOOLS_PATH
 
-    # Install dependencies
-    ssh ubuntu@$DEVICE_IP '
-      sudo snap install --classic snapcraft
-      sudo snap install lxd --channel=5.21/stable
-      sudo adduser ubuntu lxd
-      sudo snap refresh
-    '
+    # ensure device is available before continuing
+    wait_for_ssh --allow-degraded
 
-    # Disable swap and IPv6
-    ssh ubuntu@$DEVICE_IP '
-      sudo sysctl -w vm.swappiness=0
-      sudo echo "vm.swappiness = 0" | sudo tee -a /etc/sysctl.conf
-      sudo swapoff -a
-      echo "net.ipv6.conf.all.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.default.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.lo.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
-      sudo sysctl -p
-    '
+    echo
+    echo "====== TARGET DEVICE CONNECTION INFO ======"
+    echo
+    echo DEVICE_IP: ubuntu@$DEVICE_IP
+    echo
+    echo "==========================================="
+    echo
 
-    # Install intel-npu-driver snap from latest/edge, where it was published in latest PR
-    ssh ubuntu@$DEVICE_IP '
-      lxd init --auto
-      sudo snap install intel-npu-driver --channel latest/edge
-    '
+    _run sudo snap install intel-npu-driver --channel latest/edge
 
     echo "[INFO]: Sleeping for 60 seconds to ensure the firmware search path is updated."
     sleep 60
 
-    # Check firmware is deployed to the expected path
-    ssh ubuntu@$DEVICE_IP '
-      set -e
-      fw_search_path=$(sudo cat /sys/module/firmware_class/parameters/path)
-      echo "[INFO]: fw_search_path: ${fw_search_path}"
-      echo "[INFO]: $(snap services intel-npu-driver.load-npu-firmware)"
-      echo "[INFO]: $(sudo snap logs intel-npu-driver.load-npu-firmware)"
-      if [ -z "${fw_search_path}" ]; then
-        >&2 echo "Test error: Firmware search path not updated."
-        exit 1
-      fi
-      echo "Checking for firmware in expected path..."
-      ls "${fw_search_path}"/intel/vpu/ | grep ".*.bin$"
-      echo "Test success: Found .bin file(s) in the expected path."
-    '
+    _run attachments/test/check-npu-fw.sh
 
-    # Build and install checkbox-npu snap
-    ssh ubuntu@$DEVICE_IP '
-      cd ~ubuntu/intel-npu-driver-snap/checkbox
-      sudo snap install checkbox24
-      snapcraft
-      sudo snap install --dangerous --classic ./checkbox-npu_*_amd64.snap
-    '
+    _run sudo snap install checkbox24
+    _run sudo snap install --dangerous --classic attachments/test/checkbox-npu.snap
 
-    # Enable non-root access to the NPU device node
-    ssh ubuntu@$DEVICE_IP '
-      sudo usermod -a -G render $USER
-      sudo chown root:render /dev/accel/accel0
-      sudo chmod g+rw /dev/accel/accel0
-    '
+    _run sudo usermod -a -G render $USER
+    _run sudo chown root:render /dev/accel/accel0
+    _run sudo chmod g+rw /dev/accel/accel0
 
-    # Install test dependencies
-    ssh ubuntu@$DEVICE_IP '
-      checkbox-npu.install-full-deps
-    '
-
-    # Run tests
-    ssh ubuntu@$DEVICE_IP '
-      checkbox-npu.test-runner-automated
-    '
+    _run checkbox-npu.install-full-deps
+    _run checkbox-npu.test-runner-automated

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -29,6 +29,7 @@ test_data:
     echo "==========================================="
     echo
 
+    _run sudo snap refresh
     _run sudo snap install intel-npu-driver --channel latest/edge
 
     echo "[INFO]: Sleeping for 60 seconds to ensure the firmware search path is updated."
@@ -57,6 +58,8 @@ test_data:
     echo
     _run checkbox-npu.test-runner-automated
 
+    # Avoid GPG errors on old unsupported versions of Chrome, which we don't test anyway
+    _run sudo rm /etc/apt/sources.list.d/google-chrome.list
     # Upgrade apt packages, primarily to revalidate against a newer kernel
     _run sudo apt-get update
     _run sudo apt-get -y upgrade

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -8,6 +8,8 @@ test_data:
       agent: "checkbox-npu.snap"
     - local: ".github/testflinger/check-npu-fw.sh"
       agent: "check-npu-fw.sh"
+    - local: ".github/testflinger/run-checkbox-npu.sh"
+      agent: "run-checkbox-npu.sh"
   test_cmds: |
 
     set -x
@@ -29,6 +31,9 @@ test_data:
     echo "==========================================="
     echo
 
+    # Avoid GPG errors on old unsupported versions of Chrome, which we don't test anyway
+    _run sudo rm /etc/apt/sources.list.d/google-chrome.list
+
     _run sudo snap refresh
     _run sudo snap install intel-npu-driver --channel latest/edge
 
@@ -42,37 +47,18 @@ test_data:
     _put attachments/test/checkbox-npu.snap :/home/ubuntu/checkbox-npu.snap
     _run sudo snap install --dangerous --classic /home/ubuntu/checkbox-npu.snap
 
-    _run sudo usermod -a -G render ubuntu
-    _run sudo chown root:render /dev/accel/accel0
-    _run sudo chmod g+rw /dev/accel/accel0
+    _put attachments/test/run-checkbox-npu.sh :/home/ubuntu/run-checkbox-npu.sh
 
-    _run sudo apt-get install -y curl
-    _run checkbox-npu.install-full-deps
-    echo
-    echo "========= Checkbox NPU ========="
-    echo "====== DEVICE KERNEL INFO ======"
-    echo
-    _run uname -a
-    echo
-    echo "==========================================="
-    echo
-    _run checkbox-npu.test-runner-automated
+    # Run the validation twice:
+    #
+    # Run 1: original debs and kernel from the certified image
+    # Run 2: upgraded debs and kernel, following a reboot
+    #
+    _run sudo bash run-checkbox-npu.sh
 
-    # Avoid GPG errors on old unsupported versions of Chrome, which we don't test anyway
-    _run sudo rm /etc/apt/sources.list.d/google-chrome.list
-    # Upgrade apt packages, primarily to revalidate against a newer kernel
     _run sudo apt-get update
     _run sudo apt-get -y upgrade
     _run sudo reboot
     wait_for_ssh --allow-degraded
 
-    _run checkbox-npu.install-full-deps
-    echo
-    echo "========= Checkbox NPU ========="
-    echo "====== DEVICE KERNEL INFO ======"
-    echo
-    _run uname -a
-    echo
-    echo "==========================================="
-    echo
-    _run checkbox-npu.test-runner-automated
+    _run sudo bash run-checkbox-npu.sh

--- a/.github/testflinger/run-checkbox-npu.sh
+++ b/.github/testflinger/run-checkbox-npu.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+usermod -a -G render ubuntu
+# Newer versions of Ubuntu ship Udev rules which handle this,
+# but 22.04 does not
+chown root:render /dev/accel/accel0
+chmod g+rw /dev/accel/accel0
+
+checkbox-npu.install-full-deps
+
+echo
+echo "========= Checkbox NPU ========="
+echo "====== DEVICE KERNEL INFO ======"
+echo
+uname -a
+echo
+echo "================================"
+echo
+
+checkbox-npu.test-runner-automated

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -49,8 +49,7 @@ jobs:
   testflinger-validation:
     name: Testflinger Validation
     needs: build-checkbox-provider
-    runs-on: [testflinger]
-    #runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     strategy:
       matrix:
         device:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -9,9 +9,10 @@ on:
       - 'checkbox/checkbox-provider-npu/**'
       - 'checkbox/snap/**'
       - '.github/workflows/integration-tests.yaml'
-      - '.github/testflinger/job-def.yaml'
+      - '.github/testflinger/**'
     branches:
       - "main"
+      - "frenchwr/cert-team-tooling" # temporary for testing
   workflow_dispatch:
 
 concurrency:
@@ -21,17 +22,34 @@ concurrency:
 jobs:
   testflinger-validation:
     name: Testflinger Validation
-    runs-on: [testflinger]
+    runs-on: [self-hosted]
+    strategy:
+      matrix:
+        device:
+          # Dell XPS 13 9340, Meteor Lake, 22.04
+          - { queue: dell-xps-13-9340-c32267, image: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso }
+          # Dell XPS 13 9340, Meteor Lake, 24.04
+          - { queue: dell-xps-13-9340-c34207, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+          # Dell Pro Max 14, Arrow Lake, 24.04
+          - { queue: dell-precision-5680-c31665, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+        with: 
+          snapcraft-project-root: checkbox
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+        with:
+          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
       - name: Build job file from template with oemscript provisioning
-        env:
-          QUEUE: "dell-xps-13-9340-c32267"
-          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
         run: |
-          sed -e "s|REPLACE_QUEUE|${QUEUE}|" \
-          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          sed -e "s|REPLACE_QUEUE|${{ matrix.device.queue }}|" \
+          -e "s|REPLACE_IMAGE_URL|${{ matrix.device.image }}|" \
+          -e "s|REPLACE_ATTACHMENT|${{ steps.build.outputs.snap }}|" \
           ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
           ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,7 +12,6 @@ on:
       - '.github/testflinger/**'
     branches:
       - "main"
-      - "frenchwr/cert-team-tooling" # temporary for testing
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,9 +19,35 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SNAP_ARTIFACT_NAME: checkbox-npu-snap
+  SNAP_FILE: checkbox-npu.snap
+
 jobs:
+  build-checkbox-provider:
+    name: Checkbox provider build
+    runs-on: [ubuntu-latest]
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+        with:
+          snapcraft-project-root: checkbox
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+        with:
+          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+          snapcraft-args: "-o ${{ env.SNAP_FILE }}"
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
+          path: ${{ steps.build.outputs.snap }}
   testflinger-validation:
     name: Testflinger Validation
+    needs: build-checkbox-provider
     runs-on: [testflinger]
     #runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     strategy:
@@ -36,21 +62,14 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Find and parse snapcraft.yaml
-        id: snapcraft-yaml
-        uses: snapcrafters/ci/parse-snapcraft-yaml@main
-        with: 
-          snapcraft-project-root: checkbox
-      - name: Build snap
-        uses: snapcore/action-build@v1
-        id: build
+      - uses: actions/download-artifact@v4
         with:
-          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
       - name: Build job file from template with oemscript provisioning
         run: |
           sed -e "s|REPLACE_QUEUE|${{ matrix.device.queue }}|" \
           -e "s|REPLACE_IMAGE_URL|${{ matrix.device.image }}|" \
-          -e "s|REPLACE_ATTACHMENT|${{ steps.build.outputs.snap }}|" \
+          -e "s|REPLACE_ATTACHMENT|${{ env.SNAP_FILE }}|" \
           ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
           ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job
@@ -60,6 +79,7 @@ jobs:
           job-path: ${{ github.workspace }}/job.yaml
   tag:
     name: Push tag for revision
+    needs: testflinger-validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,7 +26,8 @@ env:
 jobs:
   build-checkbox-provider:
     name: Checkbox provider build
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
+    steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Find and parse snapcraft.yaml

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   testflinger-validation:
     name: Testflinger Validation
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     strategy:
       matrix:
         device:
@@ -61,6 +61,8 @@ jobs:
     name: Push tag for revision
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
       - name: Create and push tag for revision
         shell: bash
         env:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -58,7 +58,8 @@ jobs:
           # Dell XPS 13 9340, Meteor Lake, 24.04
           - { queue: dell-xps-13-9340-c34207, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
           # Dell Pro Max 14, Arrow Lake, 24.04
-          - { queue: dell-precision-5680-c31665, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+          - { queue: dell-pro-max-14-mc14250-0cf0-c36739, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+      fail-fast: false
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -22,7 +22,8 @@ concurrency:
 jobs:
   testflinger-validation:
     name: Testflinger Validation
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: [testflinger]
+    #runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     strategy:
       matrix:
         device:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To install the snap, you most likely want to install it from the Snap Store. For
 ### Installing the snap from the snap store
 
 ```
-sudo snap install intel-npu-driver --beta
+sudo snap install intel-npu-driver
 ```
 
 ### Building and installing the snap locally

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -22,6 +22,7 @@ intel-npu-driver.npu-umd-test -l 2>&1 >/dev/null
 set -e
 
 # Download the data for the test and create a simple config
+sudo apt-get install -y curl
 cd $HOME/snap/intel-npu-driver/current
 mkdir -p models/add_abc
 curl -s -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml


### PR DESCRIPTION
This updates the integration testing with the following major changes:

* Migrate to [cert-team tooling](https://github.com/canonical/certification-lab-ci-tools?tab=readme-ov-file#downloadable-installer) in `test_cmds` 
* Add two more devices for testing (three total). The devices now include three Dell laptops (sadly I still cannot successfully provision a LNL machine through testflinger):
  * MTL with 22.04 image - Dell XPS 13 9340
  * MTL with 24.04 image - Dell XPS 13 9340
  * ARL with 24.04 - Dell Pro Max 14
* Switch to private endpoint runners rather than the runners that were manually deployed to this repo several months ago. The private endpoint runners are available across the org and enable access to testflinger.
* Support testing multiple kernel versions. Each testflinger job first tests against the kernel that comes with the OS image, then performs an `apt upgrade` to install the latest supported kernel, reboots, and tests against this kernel.

## Testing

[Example workflow](https://github.com/canonical/intel-npu-driver-snap/actions/runs/15590039846) showing everything passing on a test branch.