### PR TITLE
Improve automation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,11 @@
-name: Pull Request
+name: Build
 
 on:
   pull_request:
     paths:
       - 'snap/**'
       - 'bin/**'
-      - '.github/workflows/pull-request.yaml'
+      - '.github/workflows/build.yaml'
     branches: ["**"]
 
 concurrency:
@@ -14,9 +14,11 @@ concurrency:
 
 jobs:
   build:
-    name: Build snap, run smoke tests, release to edge
+    name: Build snap and run smoke tests
     runs-on: [self-hosted, linux, X64, xlarge, jammy]
-    if: ${{ github.actor != 'renovate[bot]' }}
+    # Only run on PRs from branches in the same repository (not forks)
+    # This ensures only trusted sources can trigger this workflow
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout the source
         uses: actions/checkout@v6
@@ -54,11 +56,9 @@ jobs:
         run: |
           echo "Checking for the user mode driver command in the snap..."
           command -V intel-npu-driver.npu-umd-test
-      - name: Release to latest/edge
-        id: publish
-        shell: bash
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
-          SNAP_FILE: ${{ steps.build.outputs.snap }}
-        run: |
-          snapcraft upload "$SNAP_FILE" --release=latest/edge
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intel-npu-driver-snap-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 30

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,12 +1,10 @@
 name: Integration tests
 
 on:
-  push:
-    paths:
-      - 'snap/**'
-      - 'bin/**'
-      - '.github/workflows/integration-tests.yaml'
-      - '.github/testflinger/**'
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
     branches:
       - "main"
   workflow_dispatch:
@@ -22,6 +20,8 @@ jobs:
   testflinger-validation:
     name: Testflinger Validation
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
+    # Only run if the release workflow completed successfully
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         device:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Testflinger Validation
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
     # Only run if the release workflow completed successfully
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         device:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,49 +10,29 @@ on:
     branches:
       - "main"
   workflow_dispatch:
-    inputs:
-      snap_artifact:
-        description: 'Snap artifact name from build workflow (leave empty for latest)'
-        required: false
-        type: string
 
 jobs:
   release:
     name: Release snap to store
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
     steps:
-      - name: Download snap artifact
-        uses: dawidd6/action-download-artifact@v6
+      - name: Checkout the source
+        uses: actions/checkout@v6
+
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
         with:
-          workflow: build.yaml
-          workflow_conclusion: success
-          name: ${{ inputs.snap_artifact }}
-          name_is_regexp: ${{ inputs.snap_artifact == '' }}
-          search_artifacts: true
-          if_no_artifact_found: fail
-          # If no artifact name provided, get the most recent one
-          skip_unpack: false
-
-      - name: Find snap file
-        id: find-snap
-        shell: bash
-        run: |
-          SNAP_FILE=$(find . -name "*.snap" -type f | head -n 1)
-          if [ -z "$SNAP_FILE" ]; then
-            echo "Error: No snap file found in artifact"
-            exit 1
-          fi
-          echo "snap-file=$SNAP_FILE" >> $GITHUB_OUTPUT
-          echo "Found snap file: $SNAP_FILE"
-
-      - name: Install snapcraft
-        run: |
-          sudo snap install snapcraft --classic
+          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
 
       - name: Release to snap store
         shell: bash
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
-          SNAP_FILE: ${{ steps.find-snap.outputs.snap-file }}
+          SNAP_FILE: ${{ steps.build.outputs.snap }}
         run: |
           snapcraft upload "$SNAP_FILE" --release=latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    paths:
+      - 'snap/**'
+      - 'bin/**'
+      - '.github/workflows/build.yaml'
+      - '.github/workflows/release.yaml'
+    branches:
+      - "main"
+  workflow_dispatch:
+    inputs:
+      snap_artifact:
+        description: 'Snap artifact name from build workflow (leave empty for latest)'
+        required: false
+        type: string
+
+jobs:
+  release:
+    name: Release snap to store
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download snap artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build.yaml
+          workflow_conclusion: success
+          name: ${{ inputs.snap_artifact }}
+          name_is_regexp: ${{ inputs.snap_artifact == '' }}
+          search_artifacts: true
+          if_no_artifact_found: fail
+          # If no artifact name provided, get the most recent one
+          skip_unpack: false
+
+      - name: Find snap file
+        id: find-snap
+        shell: bash
+        run: |
+          SNAP_FILE=$(find . -name "*.snap" -type f | head -n 1)
+          if [ -z "$SNAP_FILE" ]; then
+            echo "Error: No snap file found in artifact"
+            exit 1
+          fi
+          echo "snap-file=$SNAP_FILE" >> $GITHUB_OUTPUT
+          echo "Found snap file: $SNAP_FILE"
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+
+      - name: Release to snap store
+        shell: bash
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
+          SNAP_FILE: ${{ steps.find-snap.outputs.snap-file }}
+        run: |
+          snapcraft upload "$SNAP_FILE" --release=latest/edge

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^snap/snapcraft\\.yaml$"],
+      "matchStrings": [
+        "source:\\s+https://github\\.com/(?<depName>[^/]+/[^/]+)\\.git\\s+source-tag:\\s+(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
   ]
 }


### PR DESCRIPTION
- Configure renovate to watch upstream

Tweaks to CI:
- Instead of publishing to latest/edge when changes are still from a PR,
upload the snap as a snap artifact where it can be downloaded for manual
testing.
- Create a release workflow that triggers on PR merges. When successful,
trigger integration testing from latest/edge (where the snap is
published from the release workflow).