### PR TITLE
Add npu-umd-test wrapper script

### DIFF
--- a/bin/npu-umd-test-wrapper
+++ b/bin/npu-umd-test-wrapper
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Check if user passed --config or -c
+for arg in "$@"; do
+    if [[ "$arg" == "--config" || "$arg" == "-c" ]]; then
+        exec npu-umd-test "$@"
+    fi
+done
+
+# No --config provided, use the snap's default
+exec npu-umd-test --config "$SNAP/usr/share/vpu/validation/umd-test/configs/basic.yaml" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,7 +56,7 @@ layout:
 
 apps:
   npu-umd-test:
-    command: usr/bin/npu-umd-test
+    command: usr/bin/npu-umd-test-wrapper
     plugs: [intel-npu-plug]
 
   known-failures:


### PR DESCRIPTION
New versions of npu-umd-test no longer auto-load config files from a default path, the --config option must be always passed explictly. To allow users to pass their own config, this adds a wrapper script that checks for the --config flag, and if present passes it on to npu-umd-test, else the default config inside the snap is used.