### PR TITLE
Fix models used by npu-umd-test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'snap/**'
       - 'bin/**'
+      - 'config/**'
       - '.github/workflows/build.yaml'
     branches: ["**"]
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -177,6 +177,8 @@ jobs:
     name: Push tag for revision
     needs: testflinger-validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the source
         uses: actions/checkout@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'snap/**'
       - 'bin/**'
-      - '.github/workflows/build.yaml'
+      - 'config/**'
       - '.github/workflows/release.yaml'
     branches:
       - "main"

--- a/config/basic.yaml
+++ b/config/basic.yaml
@@ -11,7 +11,7 @@
 # the License.
 
 log_level: ERROR # supported levels:QUIET ERROR, WARNING, INFO, VERBOSE
-model_dir: /usr/share/vpu/models/
+model_dir: /usr/share/vpu/validation/umd-test/configs/models/
 
 graph_execution:
   # add_abc.xml can be copied from OpenVINO repository:

--- a/config/models/mul_add/mul_add.xml
+++ b/config/models/mul_add/mul_add.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<net name="Model0" version="11">
+	<layers>
+		<layer id="2" name="Parameter_1" type="Parameter" version="opset1">
+			<data shape="2,3,4" element_type="f16" />
+			<output>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="1" name="Parameter_2" type="Parameter" version="opset1">
+			<data shape="2,3,4" element_type="f16" />
+			<output>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="0" name="Parameter_3" type="Parameter" version="opset1">
+			<data shape="2,3,4" element_type="f16" />
+			<output>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="3" name="Multiply_4" type="Multiply" version="opset1">
+			<data auto_broadcast="numpy" />
+			<input>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+				<port id="1" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</input>
+			<output>
+				<port id="2" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="4" name="Add_5" type="Add" version="opset1">
+			<data auto_broadcast="numpy" />
+			<input>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+				<port id="1" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</input>
+			<output>
+				<port id="2" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</output>
+		</layer>
+		<layer id="6" name="Result_6" type="Result" version="opset1">
+			<input>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</input>
+		</layer>
+		<layer id="5" name="Result_7" type="Result" version="opset1">
+			<input>
+				<port id="0" precision="FP16">
+					<dim>2</dim>
+					<dim>3</dim>
+					<dim>4</dim>
+				</port>
+			</input>
+		</layer>
+	</layers>
+	<edges>
+		<edge from-layer="0" from-port="0" to-layer="4" to-port="1" />
+		<edge from-layer="1" from-port="0" to-layer="3" to-port="1" />
+		<edge from-layer="2" from-port="0" to-layer="3" to-port="0" />
+		<edge from-layer="3" from-port="2" to-layer="4" to-port="0" />
+		<edge from-layer="3" from-port="2" to-layer="6" to-port="0" />
+		<edge from-layer="4" from-port="2" to-layer="5" to-port="0" />
+	</edges>
+	<rt_info />
+</net>


### PR DESCRIPTION
* Update model path in `basic.yaml` used for validation, which I missed in https://github.com/canonical/intel-npu-driver-snap/pull/34
* Some tests from upstream now expect a `mul_add` network that is expected to follow the same path convention as the `add_abc` network already in `basic.yaml`, see https://github.com/intel/linux-npu-driver/blob/v1.33.0/docs/overview.md#driver-test-application
* Allow GitHub bot to push tags to the repo. This used to work without setting explicit write permissions but it appears the default permissions are no longer sufficient.