### PR TITLE
Add NPU plug to known-failures app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,6 +61,7 @@ apps:
 
   known-failures:
     command: usr/bin/known-failures
+    plugs: [intel-npu-plug]
 
   load-npu-firmware:
     command: usr/bin/load-npu-firmware


### PR DESCRIPTION
The `known-failures` command needs access to the NPU device node to detect the NPU type.